### PR TITLE
fix(CallModel): handle null AI response text

### DIFF
--- a/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/CallModel.java
+++ b/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/CallModel.java
@@ -68,7 +68,11 @@ public class CallModel<State extends MessagesState<ChatMessage>> implements Asyn
             return Map.of("messages", content);
         }
         if( response.finishReason() == FinishReason.STOP || response.finishReason() == null  ) {
-            return Map.of(AgentExecutor.State.FINAL_RESPONSE, content.text());
+            String responseText = content.text();
+            if (responseText == null) {
+                responseText = "";
+            }
+            return Map.of(AgentExecutor.State.FINAL_RESPONSE, responseText);
         }
 
         throw new IllegalStateException("Unsupported finish reason: " + response.finishReason() );


### PR DESCRIPTION
## 🔧 Fix for Issue #221 

### Changes
- Add null check for `content.text()` in `mapResult` method
- Use empty string as fallback when AI response text is null  

### Details
This fix addresses the `java.util.concurrent.ExecutionException: java.lang.NullPointerException` that occurs in `CallModel.mapResult()` when:
1. AI model returns a response with `FinishReason.STOP` or `null`
2. But `content.text()` returns `null` 
3. `Map.of()` throws NPE because it doesn't accept null values

### Testing
- Manual testing confirms the fix prevents the NPE
- Maintains backward compatibility 