### PR TITLE
Enhance multi-turn conversation support by preserving AI messages

### DIFF
--- a/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/CallModel.java
+++ b/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/CallModel.java
@@ -72,7 +72,10 @@ public class CallModel<State extends MessagesState<ChatMessage>> implements Asyn
             if (responseText == null) {
                 responseText = "";
             }
-            return Map.of(AgentExecutor.State.FINAL_RESPONSE, responseText);
+            return Map.of(
+                "messages", content,
+                AgentExecutor.State.FINAL_RESPONSE, responseText
+            );
         }
 
         throw new IllegalStateException("Unsupported finish reason: " + response.finishReason() );


### PR DESCRIPTION
# Enhance Multi-turn Conversation Support by Preserving AI Messages 
##  for Issue #245  
## 🎯 Overview

This PR improves multi-turn conversation support in the AgentExecutor by ensuring AI messages are preserved in conversation history when `FinishReason` is `STOP` or `null`.

## 🔍 Problem

Previously, when an AI model responded with `FinishReason.STOP`, the `CallModel.mapResult()` method only returned:
```java
return Map.of(AgentExecutor.State.FINAL_RESPONSE, responseText);
```

This approach worked well for single-turn interactions but created limitations for multi-turn conversations where maintaining message history is crucial for context continuity.

## ✅ Solution

Modified `CallModel.mapResult()` to preserve both the AI message and the final response:
```java
return Map.of(
    "messages", content,
    AgentExecutor.State.FINAL_RESPONSE, responseText
);
```

## 🔧 Changes Made

### Core Changes
- **Modified**: `CallModel.mapResult()` method in `langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/CallModel.java`
  - Now includes both `"messages"` and `FINAL_RESPONSE` in the return map for STOP finish reasons
  - Maintains backward compatibility by preserving existing `FINAL_RESPONSE` behavior

## 🎯 Benefits

### For Users
- **Seamless Multi-turn Conversations**: AI responses are automatically preserved in conversation history
- **Improved Context Continuity**: Subsequent interactions have access to full conversation context
- **Zero Breaking Changes**: Existing single-turn workflows continue to work unchanged

### For Framework
- **Consistency**: All response types now preserve message history uniformly
- **Future-proof Design**: Aligns with conversational AI application patterns
