### PR TITLE
feat: add DynamoDB-based checkpoint saver implementation 

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/CompiledGraph.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/CompiledGraph.java
@@ -30,6 +30,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.bsc.langgraph4j.action.SubCompiledGraphNodeAction.resumeSubGraphId;
 import static org.bsc.langgraph4j.utils.CollectionsUtils.mergeMap;
 
 /**
@@ -667,7 +668,7 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
 
         final Context context;
         int iteration = 0;
-        final RunnableConfig config;
+        private RunnableConfig config;
 
         protected AsyncNodeGenerator(GraphInput input, RunnableConfig config )  {
             final var configBuilder = RunnableConfig.builder(config)
@@ -887,6 +888,9 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
                         future = completedFuture( returnFromEmbed.asStateDataOrLastCheckpointStateData() );
                     }
 
+                    config = config.removeMetadata(
+                            resumeSubGraphId( context.currentNodeId() ),
+                            RunnableConfig.SUBGRAPH_RESUME_UPDATE_DATA );
 
                     return Data.of( future.thenCompose( TryFunction.Try((partialResult) -> {
 
@@ -945,7 +949,8 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
 
                 context.setCurrentNodeId( context.nextNodeId() );
 
-                final var newConfig = updateRunnableConfigMetadata( config, context.currentNodeId() );
+                // final var newConfig = updateRunnableConfigMetadata( config, context.currentNodeId() );
+                config = updateRunnableConfigMetadata( config, context.currentNodeId() );
 
                 //
                 // EVALUATE ACTION
@@ -958,7 +963,7 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
                 final var clonedState = cloneState(context.currentState());
 
                 try {
-                    return applyAction(action, context.currentNodeId(), clonedState, newConfig);
+                    return applyAction(action, context.currentNodeId(), clonedState, config);
                 }
                 catch( InterruptedException ex ) {
                     if( action instanceof ParallelNode.AsyncParallelNodeAction<?> parallelNodeAction ) {

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/CompiledGraph.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/CompiledGraph.java
@@ -63,8 +63,8 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
          * @param args the arguments to format the error message
          * @return a new GraphRunnerException
          */
-        GraphRunnerException exception(String... args) {
-            return new GraphRunnerException(format(errorMessage, (Object[]) args));
+        GraphRunnerException exception(RunnableConfig config, String... args) {
+            return new GraphRunnerException( config, errorMessage.formatted( (Object[]) args));
         }
     }
 
@@ -324,7 +324,7 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
     private Command nextNodeId(EdgeValue<State> route , Map<String,Object> state, String nodeId, RunnableConfig config ) throws Exception {
 
         if( route == null ) {
-            throw RunnableErrors.missingEdge.exception(nodeId);
+            throw RunnableErrors.missingEdge.exception(config,nodeId);
         }
         if( route.id() != null ) {
             return new Command(route.id(), state);
@@ -349,14 +349,14 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
 
             final String result = route.value().mappings().get(newRoute);
             if( result == null ) {
-                throw RunnableErrors.missingNodeInEdgeMapping.exception(nodeId, newRoute);
+                throw RunnableErrors.missingNodeInEdgeMapping.exception(config, nodeId, newRoute);
             }
 
             final var currentState = AgentState.updateState(state, command.update(), stateGraph.getChannels());
 
             return new Command(result, currentState);
         }
-        throw RunnableErrors.executionError.exception( format("invalid edge value for nodeId: [%s] !", nodeId) );
+        throw RunnableErrors.executionError.exception( config, format("invalid edge value for nodeId: [%s] !", nodeId) );
     }
 
     /**
@@ -953,7 +953,7 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
                 final var action = nodes.get( context.currentNodeId() );
 
                 if (action == null)
-                    throw RunnableErrors.missingNode.exception(context.currentNodeId());
+                    throw RunnableErrors.missingNode.exception(config, context.currentNodeId());
 
                 final var clonedState = cloneState(context.currentState());
 
@@ -968,9 +968,13 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
                 }
 
             }
+            catch( GraphRunnerException e ) {
+                log.error( e.getMessage(), e );
+                return Data.error( e );
+            }
             catch( Throwable e ) {
                 log.error( e.getMessage(), e );
-                return Data.error(e);
+                return Data.error( new GraphRunnerException( config, e) );
             }
 
         }

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/GraphRunnerException.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/GraphRunnerException.java
@@ -1,16 +1,26 @@
 package org.bsc.langgraph4j;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Exception thrown when there is an error during the execution of a graph runner.
  */
 public class GraphRunnerException extends Exception {
 
-    /**
-     * Constructs a new GraphRunnerException with the specified error message.
-     *
-     * @param errorMessage the detail message
-     */
-    public GraphRunnerException(String errorMessage) {
+    private final RunnableConfig config;
+
+    public GraphRunnerException(RunnableConfig config, String errorMessage ) {
         super(errorMessage);
+        this.config = requireNonNull(config, "config cannot be null");
+
+    }
+
+    public GraphRunnerException(RunnableConfig config, Throwable cause ) {
+        super(cause);
+        this.config = requireNonNull(config, "config cannot be null");;
+    }
+
+    public RunnableConfig config() {
+        return config;
     }
 }

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/RunnableConfig.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/RunnableConfig.java
@@ -64,9 +64,7 @@ public final class RunnableConfig implements HasMetadata {
         this.checkPointId   = builder.checkPointId;
         this.nextNode       = builder.nextNode;
         this.streamMode     = builder.streamMode;
-        this.metadata       = ofNullable(builder.metadata())
-                .map( Map::copyOf )
-                .orElse(null);
+        this.metadata       = builder.metadata();
     }
 
     @Override
@@ -162,6 +160,17 @@ public final class RunnableConfig implements HasMetadata {
                 .build();
     }
 
+    public RunnableConfig removeMetadata( String ...keys ) {
+        if( metadata == null || metadata.isEmpty() ) return this;
+
+        final var resultBuilder = new RunnableConfig.Builder( this);
+        for (String key : keys) {
+            resultBuilder.removeMetadata(key);
+        }
+        return resultBuilder.build();
+    }
+
+
     @Override
     public Set<String> metadataKeys() {
         return ofNullable(metadata).map( Map::keySet ).orElseGet(Set::of);
@@ -251,6 +260,10 @@ public final class RunnableConfig implements HasMetadata {
             this.nextNode       = config.nextNode;
             this.streamMode     = config.streamMode;
 
+        }
+
+        public Builder graphId(String graphId) {
+            return super.addMetadata(GRAPH_ID, graphId);
         }
 
         /**

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/CancellationTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/CancellationTest.java
@@ -261,7 +261,8 @@ public class CancellationTest {
                 log.info("iteration is on: {}", output);
             }).exceptionally(ex -> {
                 assertTrue(generator.isCancelled());
-                assertInstanceOf(InterruptedException.class, ex.getCause());
+                assertInstanceOf(GraphRunnerException.class, ex.getCause());
+                assertInstanceOf(InterruptedException.class, ExceptionUtils.getRootCause(ex));
                 assertEquals( 2, taskExecuted.get() );
                 return "CANCELLED";
             });

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/CompiledSubGraphTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/CompiledSubGraphTest.java
@@ -151,7 +151,9 @@ public class CompiledSubGraphTest {
                     .orElseThrow();
 
             if (!output.isEND()) {
-                throw new SubGraphInterruptionException(parentNodeId,
+                throw new SubGraphInterruptionException(
+                        config,
+                        parentNodeId,
                         output.node(),
                         mergeMap(output.state().data(), Map.of("resume_subgraph", true)));
             }

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/exception/SubGraphInterruptionException.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/exception/SubGraphInterruptionException.java
@@ -1,6 +1,7 @@
 package org.bsc.langgraph4j.exception;
 
 import org.bsc.langgraph4j.GraphRunnerException;
+import org.bsc.langgraph4j.RunnableConfig;
 import org.bsc.langgraph4j.action.InterruptionMetadata;
 import org.bsc.langgraph4j.state.AgentState;
 
@@ -15,16 +16,16 @@ public class SubGraphInterruptionException extends GraphRunnerException {
     final Map<String, Object> state;
     final InterruptionMetadata<? extends AgentState> interruptionMetadata;
 
-    public SubGraphInterruptionException(String parentNodeId, String nodeId, Map<String, Object> state) {
-        super(format("interruption in subgraph: %s on node: %s", parentNodeId, nodeId));
+    public SubGraphInterruptionException(RunnableConfig config,String parentNodeId, String nodeId, Map<String, Object> state) {
+        super(config, format("interruption in subgraph: %s on node: %s", parentNodeId, nodeId));
         this.parentNodeId = parentNodeId;
         this.nodeId = nodeId;
         this.state = state;
         interruptionMetadata = null;
     }
 
-    public SubGraphInterruptionException(InterruptionMetadata<? extends AgentState> interruptionMetadata) {
-        super(format("interruption in subgraph: %s on node: %s", "NONE", interruptionMetadata.nodeId()));
+    public SubGraphInterruptionException(RunnableConfig config, InterruptionMetadata<? extends AgentState> interruptionMetadata) {
+        super(config,format("interruption in subgraph: %s on node: %s", "NONE", interruptionMetadata.nodeId()));
         this.parentNodeId = "NONE";
         this.nodeId = interruptionMetadata.nodeId();
         this.state = interruptionMetadata.state().data();

--- a/langgraph4j-dynamodb-saver/pom.xml
+++ b/langgraph4j-dynamodb-saver/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.bsc.langgraph4j</groupId>
+        <artifactId>langgraph4j-parent</artifactId>
+        <version>1.8.14</version>
+    </parent>
+
+    <artifactId>langgraph4j-dynamodb-saver</artifactId>
+    <packaging>jar</packaging>
+
+    <description>Amazon DynamoDB Checkpoint Saver for LangGraph4j</description>
+    <name>langgraph4j::dynamodb-saver</name>
+    <url>https://github.com/langgraph4j/langgraph4j</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/langgraph4j/langgraph4j.git</connection>
+        <developerConnection>scm:git:https://github.com/langgraph4j/langgraph4j.git</developerConnection>
+        <url>https://github.com/langgraph4j/langgraph4j</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <aws.sdk.version>2.27.21</aws.sdk.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- LangGraph4j core -->
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>langgraph4j-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <!-- AWS SDK v2 – DynamoDB (Enhanced Client included) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+
+        <!-- AWS SDK v2 – URL Connection HTTP client (lightweight, no Netty) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Integration tests (ITest suffix) are excluded from unit test run -->
+                    <excludes>
+                        <exclude>**/*ITest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/langgraph4j-dynamodb-saver/pom.xml
+++ b/langgraph4j-dynamodb-saver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.bsc.langgraph4j</groupId>
         <artifactId>langgraph4j-parent</artifactId>
-        <version>1.8.14</version>
+        <version>1.8.15</version>
     </parent>
 
     <artifactId>langgraph4j-dynamodb-saver</artifactId>

--- a/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBRepository.java
+++ b/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBRepository.java
@@ -1,0 +1,369 @@
+package org.bsc.langgraph4j.checkpoint;
+
+import static java.lang.String.format;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+/**
+ * Low-level DynamoDB operations for the {@link DynamoDBSaver}.
+ *
+ * <h2>Key-naming conventions (single-table design)</h2>
+ * <pre>
+ *   PK                                     SK                Description
+ *   ─────────────────────────────────────  ────────────────  ─────────────────────────────
+ *   CHECKPOINT_{threadId}                  {checkpointId}    Checkpoint metadata item
+ *   CHUNK_{threadId}#{checkpointId}        CHUNK             Serialized state payload
+ *   RELEASED_{threadId}                    MARKER            Thread-released sentinel
+ * </pre>
+ *
+ * <p>
+ * All item attributes:
+ * <ul>
+ * <li>{@code PK} – partition key</li>
+ * <li>{@code SK} – sort key</li>
+ * <li>{@code checkpointId} – UUID string</li>
+ * <li>{@code nodeId} – current node name</li>
+ * <li>{@code nextNodeId} – next node name</li>
+ * <li>{@code contentType} – serializer content-type string</li>
+ * <li>{@code payload} – binary; only present in CHUNK items</li>
+ * <li>{@code ttl} – optional epoch-second number for DynamoDB TTL</li>
+ * </ul>
+ */
+class DynamoDBRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(DynamoDBRepository.class);
+
+    // ─── PK/SK generators ───────────────────────────────────────────────────────
+    static String checkpointPK(String threadId) {
+        return "CHECKPOINT_" + threadId;
+    }
+
+    static String checkpointSK(String checkpointId) {
+        return checkpointId;
+    }
+
+    static String chunkPK(String threadId, String checkpointId) {
+        return format("CHUNK_%s#%s", threadId, checkpointId);
+    }
+
+    static String chunkSK() {
+        return "CHUNK";
+    }
+
+    static String releasedPK(String threadId) {
+        return "RELEASED_" + threadId;
+    }
+
+    static String releasedSK() {
+        return "MARKER";
+    }
+
+    // ─── Record type returned to DynamoDBSaver ──────────────────────────────────
+    /**
+     * Immutable view of a checkpoint as loaded from DynamoDB.
+     */
+    record CheckpointRecord(
+            String threadId,
+            String checkpointId,
+            String nodeId,
+            String nextNodeId,
+            byte[] payload,
+            String contentType,
+            Long savedAt
+            ) {
+
+    }
+
+    // ─── Fields ─────────────────────────────────────────────────────────────────
+    private final DynamoDbClient client;
+    private final String tableName;
+    private final Long ttlSeconds;
+
+    // ─── Constructor ─────────────────────────────────────────────────────────────
+    DynamoDBRepository(DynamoDbClient client, String tableName, Long ttlSeconds) {
+        this.client = client;
+        this.tableName = tableName;
+        this.ttlSeconds = ttlSeconds;
+    }
+
+    // ─── Table lifecycle ─────────────────────────────────────────────────────────
+    /**
+     * Creates the DynamoDB table with {@code PK} (HASH) + {@code SK} (RANGE)
+     * composite key and {@code PAY_PER_REQUEST} billing. No-ops if the table
+     * already exists.
+     */
+    void createTableIfNotExists() {
+        try {
+            client.createTable(r -> r
+                    .tableName(tableName)
+                    .keySchema(
+                            KeySchemaElement.builder().attributeName("PK").keyType(KeyType.HASH).build(),
+                            KeySchemaElement.builder().attributeName("SK").keyType(KeyType.RANGE).build()
+                    )
+                    .attributeDefinitions(
+                            AttributeDefinition.builder().attributeName("PK")
+                                    .attributeType(ScalarAttributeType.S).build(),
+                            AttributeDefinition.builder().attributeName("SK")
+                                    .attributeType(ScalarAttributeType.S).build()
+                    )
+                    .billingMode(BillingMode.PAY_PER_REQUEST)
+            );
+
+            log.info("Created DynamoDB table '{}'", tableName);
+
+            // Wait until the table is active
+            client.waiter().waitUntilTableExists(r -> r.tableName(tableName));
+            log.debug("DynamoDB table '{}' is now ACTIVE", tableName);
+
+        } catch (ResourceInUseException e) {
+            // Table already exists – no action needed
+            log.debug("DynamoDB table '{}' already exists, skipping creation", tableName);
+        }
+    }
+
+    /**
+     * Deletes the table. Waits until the deletion is confirmed. No-ops if the
+     * table does not exist.
+     */
+    void dropTable() {
+        try {
+            client.deleteTable(r -> r.tableName(tableName));
+            log.info("Deleted DynamoDB table '{}'", tableName);
+            client.waiter().waitUntilTableNotExists(r -> r.tableName(tableName));
+        } catch (ResourceNotFoundException e) {
+            log.debug("DynamoDB table '{}' not found – nothing to drop", tableName);
+        }
+    }
+
+    // ─── Checkpoint operations ───────────────────────────────────────────────────
+    /**
+     * Persists a checkpoint metadata item and its associated payload chunk
+     * item.
+     *
+     * @param threadId thread identifier
+     * @param checkpointId UUID of the checkpoint
+     * @param nodeId current graph node
+     * @param nextNodeId next graph node
+     * @param payload serialized state bytes
+     * @param contentType serializer content-type string
+     */
+    void putCheckpoint(String threadId,
+            String checkpointId,
+            String nodeId,
+            String nextNodeId,
+            byte[] payload,
+            String contentType) {
+
+        // ── 1. Metadata item ──────────────────────────────────────────────────
+        Map<String, AttributeValue> metaItem = new HashMap<>();
+        metaItem.put("PK", s(checkpointPK(threadId)));
+        metaItem.put("SK", s(checkpointSK(checkpointId)));
+        metaItem.put("checkpointId", s(checkpointId));
+        metaItem.put("nodeId", s(nodeId));
+        metaItem.put("nextNodeId", s(nextNodeId));
+        metaItem.put("contentType", s(contentType));
+        metaItem.put("savedAt", n(Instant.now().toEpochMilli()));
+
+        if (ttlSeconds != null) {
+            metaItem.put("ttl", n(Instant.now().getEpochSecond() + ttlSeconds));
+        }
+
+        client.putItem(r -> r.tableName(tableName).item(metaItem));
+        log.debug("Stored checkpoint metadata: threadId={}, checkpointId={}", threadId, checkpointId);
+
+        // ── 2. Payload chunk item ─────────────────────────────────────────────
+        Map<String, AttributeValue> chunkItem = new HashMap<>();
+        chunkItem.put("PK", s(chunkPK(threadId, checkpointId)));
+        chunkItem.put("SK", s(chunkSK()));
+        chunkItem.put("payload", b(payload));
+
+        if (ttlSeconds != null) {
+            chunkItem.put("ttl", n(Instant.now().getEpochSecond() + ttlSeconds));
+        }
+
+        client.putItem(r -> r.tableName(tableName).item(chunkItem));
+        log.debug("Stored payload chunk: threadId={}, checkpointId={}, size={}B",
+                threadId, checkpointId, payload.length);
+    }
+
+    /**
+     * Loads all checkpoint records for the given thread, sorted newest-first.
+     * Each record's payload is fetched from the associated chunk item.
+     *
+     * @param threadId thread identifier
+     * @return list of records, ordered by checkpointId descending (UUIDs are
+     * time-based when v7, but for lexicographic ordering we rely on DynamoDB's
+     * SK scan-forward=false)
+     */
+    List<CheckpointRecord> loadCheckpointRecords(String threadId) {
+        String pk = checkpointPK(threadId);
+
+        QueryRequest query = QueryRequest.builder()
+                .tableName(tableName)
+                .keyConditionExpression("PK = :pk")
+                .expressionAttributeValues(Map.of(":pk", s(pk)))
+                .scanIndexForward(false) // newest SK first
+                .build();
+
+        List<CheckpointRecord> records = new ArrayList<>();
+
+        // Paginate through all results
+        String lastEvaluatedKey = null;
+        Map<String, AttributeValue> exclusiveStartKey = null;
+
+        do {
+            QueryRequest.Builder reqBuilder = query.toBuilder();
+            if (exclusiveStartKey != null) {
+                reqBuilder.exclusiveStartKey(exclusiveStartKey);
+            }
+
+            QueryResponse response = client.query(reqBuilder.build());
+
+            for (Map<String, AttributeValue> item : response.items()) {
+                String checkpointId = item.get("checkpointId").s();
+                String nodeId = item.get("nodeId").s();
+                String nextNodeId = item.get("nextNodeId").s();
+                String contentType = item.get("contentType").s();
+                Long savedAt = item.containsKey("savedAt") ? Long.parseLong(item.get("savedAt").n()) : 0L;
+
+                // Fetch payload from chunk item
+                byte[] payload = loadChunkPayload(threadId, checkpointId);
+                if (payload == null) {
+                    log.warn("Payload chunk not found for checkpointId='{}', thread='{}' – skipping",
+                            checkpointId, threadId);
+                    continue;
+                }
+
+                records.add(new CheckpointRecord(threadId, checkpointId, nodeId, nextNodeId, payload, contentType, savedAt));
+            }
+
+            exclusiveStartKey = response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null;
+
+        } while (exclusiveStartKey != null);
+
+        log.debug("Loaded {} checkpoint record(s) for thread '{}'", records.size(), threadId);
+        records.sort(Comparator.comparing(CheckpointRecord::savedAt).reversed());
+        return records;
+    }
+
+    /**
+     * Fetches the serialized payload for a single checkpoint from its chunk
+     * item.
+     *
+     * @return the raw bytes, or {@code null} if the item is not found
+     */
+    byte[] loadChunkPayload(String threadId, String checkpointId) {
+        GetItemResponse response = client.getItem(r -> r
+                .tableName(tableName)
+                .key(Map.of(
+                        "PK", s(chunkPK(threadId, checkpointId)),
+                        "SK", s(chunkSK())
+                ))
+                .projectionExpression("payload")
+        );
+
+        if (!response.hasItem() || !response.item().containsKey("payload")) {
+            return null;
+        }
+
+        return response.item().get("payload").b().asByteArray();
+    }
+
+    /**
+     * Deletes the checkpoint metadata item and its associated payload chunk
+     * item.
+     *
+     * @param threadId thread identifier
+     * @param checkpointId UUID of the checkpoint to delete
+     */
+    void deleteCheckpoint(String threadId, String checkpointId) {
+        // Delete metadata item
+        client.deleteItem(r -> r
+                .tableName(tableName)
+                .key(Map.of(
+                        "PK", s(checkpointPK(threadId)),
+                        "SK", s(checkpointSK(checkpointId))
+                ))
+        );
+
+        // Delete chunk item
+        client.deleteItem(r -> r
+                .tableName(tableName)
+                .key(Map.of(
+                        "PK", s(chunkPK(threadId, checkpointId)),
+                        "SK", s(chunkSK())
+                ))
+        );
+
+        log.debug("Deleted checkpoint '{}' for thread '{}'", checkpointId, threadId);
+    }
+
+    // ─── Thread release operations ───────────────────────────────────────────────
+    /**
+     * Writes a sentinel item that marks this thread as "released" (archived).
+     * Subsequent calls to {@link #isThreadReleased(String)} will return
+     * {@code true}.
+     */
+    void markThreadReleased(String threadId) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("PK", s(releasedPK(threadId)));
+        item.put("SK", s(releasedSK()));
+
+        if (ttlSeconds != null) {
+            item.put("ttl", n(Instant.now().getEpochSecond() + ttlSeconds));
+        }
+
+        client.putItem(r -> r.tableName(tableName).item(item));
+        log.info("Marked thread '{}' as released", threadId);
+    }
+
+    /**
+     * Returns {@code true} if a released sentinel item exists for the given
+     * thread.
+     */
+    boolean isThreadReleased(String threadId) {
+        GetItemResponse response = client.getItem(r -> r
+                .tableName(tableName)
+                .key(Map.of(
+                        "PK", s(releasedPK(threadId)),
+                        "SK", s(releasedSK())
+                ))
+                .projectionExpression("PK")
+        );
+        return response.hasItem();
+    }
+
+    // ─── AttributeValue helpers ──────────────────────────────────────────────────
+    private static AttributeValue s(String value) {
+        return AttributeValue.builder().s(value).build();
+    }
+
+    private static AttributeValue n(long value) {
+        return AttributeValue.builder().n(String.valueOf(value)).build();
+    }
+
+    private static AttributeValue b(byte[] value) {
+        return AttributeValue.builder().b(SdkBytes.fromByteArray(value)).build();
+    }
+}

--- a/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaver.java
+++ b/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaver.java
@@ -1,0 +1,361 @@
+package org.bsc.langgraph4j.checkpoint;
+
+import org.bsc.langgraph4j.RunnableConfig;
+import org.bsc.langgraph4j.serializer.StateSerializer;
+import org.bsc.langgraph4j.serializer.PlainTextStateSerializer;
+import org.bsc.langgraph4j.state.AgentState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Amazon DynamoDB-backed checkpoint saver for LangGraph4j.
+ *
+ * <p>Implements the {@link AbstractCheckpointSaver} contract and stores all checkpoints
+ * in a single DynamoDB table using a composite primary key ({@code PK} + {@code SK}).
+ * Checkpoint state is serialized via the supplied {@link StateSerializer} and stored as
+ * a separate "chunk" item to keep the metadata item well within DynamoDB's 400 KB limit.
+ *
+ * <h2>Table layout</h2>
+ * <pre>
+ *  PK                                    SK                   Purpose
+ *  ─────────────────────────────────     ─────────────────    ─────────────────────────────
+ *  CHECKPOINT_{threadId}                 {checkpointId}       Checkpoint metadata
+ *  CHUNK_{threadId}#{checkpointId}       CHUNK                Serialized state payload
+ *  RELEASED_{threadId}                   MARKER               Thread-released sentinel
+ * </pre>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * DynamoDBSaver saver = DynamoDBSaver.builder()
+ *     .tableName("lg4j-checkpoints")
+ *     .region("us-east-1")
+ *     .stateSerializer(new ObjectStreamStateSerializer<>(AgentState::new))
+ *     .createTableIfNotExists(true)
+ *     .build();
+ * }</pre>
+ *
+ * <p>For local development / testing, point to a local DynamoDB endpoint:
+ * <pre>{@code
+ * DynamoDBSaver saver = DynamoDBSaver.builder()
+ *     .tableName("lg4j-checkpoints")
+ *     .endpointUrl("http://localhost:8000")
+ *     .region("us-east-1")
+ *     .stateSerializer(serializer)
+ *     .createTableIfNotExists(true)
+ *     .dropTableFirst(true)
+ *     .build();
+ * }</pre>
+ */
+public class DynamoDBSaver extends AbstractCheckpointSaver {
+
+    private static final Logger log = LoggerFactory.getLogger(DynamoDBSaver.class);
+
+    // ─── Builder ────────────────────────────────────────────────────────────────
+
+    /**
+     * Fluent builder for {@link DynamoDBSaver}.
+     */
+    public static class Builder {
+
+        private String tableName;
+        private String region;
+        private String endpointUrl;
+        private AwsCredentialsProvider credentialsProvider;
+        private StateSerializer<? extends AgentState> stateSerializer;
+        private boolean plainTextStateSerializerLegacyMode = false;
+        private Long ttlSeconds;
+        private boolean createTableIfNotExists = false;
+        private boolean dropTableFirst = false;
+        /** Inject a fully configured client (useful for tests or shared clients). */
+        private DynamoDbClient dynamoDbClient;
+
+        Builder() {}
+
+        /** Name of the DynamoDB table. Required. */
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        /** AWS region (e.g. {@code "us-east-1"}). Ignored when a custom client is provided. */
+        public Builder region(String region) {
+            this.region = region;
+            return this;
+        }
+
+        /**
+         * Override the DynamoDB service endpoint URL.
+         * Useful for local DynamoDB ({@code "http://localhost:8000"}) and LocalStack.
+         */
+        public Builder endpointUrl(String endpointUrl) {
+            this.endpointUrl = endpointUrl;
+            return this;
+        }
+
+        /** Custom AWS credentials provider. Defaults to {@link DefaultCredentialsProvider}. */
+        public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+            return this;
+        }
+
+        /**
+         * The state serializer used to convert {@code Map<String,Object>} state to/from bytes.
+         * Required.
+         */
+        public <State extends AgentState> Builder stateSerializer(StateSerializer<State> stateSerializer) {
+            this.stateSerializer = stateSerializer;
+            return this;
+        }
+
+        /**
+         * Enables compatibility mode for {@link PlainTextStateSerializer}-based payloads.
+         * When {@code true}, the JSON payload is stored as a serialized Java String (binary).
+         * Ignored if the serializer is not a {@link PlainTextStateSerializer}.
+         */
+        public Builder plainTextStateSerializerLegacyMode(boolean mode) {
+            this.plainTextStateSerializerLegacyMode = mode;
+            return this;
+        }
+
+        /**
+         * Optional time-to-live in seconds. When set, every item written to DynamoDB
+         * will carry a {@code ttl} attribute (epoch seconds) so the table's TTL feature
+         * can automatically expire old checkpoints.
+         */
+        public Builder ttlSeconds(long ttlSeconds) {
+            this.ttlSeconds = ttlSeconds;
+            return this;
+        }
+
+        /**
+         * When {@code true}, the table is created (via {@code CreateTable}) if it does not
+         * already exist. Automatically implies {@code createTableIfNotExists = true} when
+         * {@link #dropTableFirst(boolean)} is also set.
+         */
+        public Builder createTableIfNotExists(boolean create) {
+            this.createTableIfNotExists = create;
+            return this;
+        }
+
+        /**
+         * When {@code true}, the table is deleted and recreated on startup.
+         * Implies {@link #createTableIfNotExists(boolean) createTableIfNotExists = true}.
+         * Useful for tests.
+         */
+        public Builder dropTableFirst(boolean drop) {
+            this.dropTableFirst = drop;
+            return this;
+        }
+
+        /**
+         * Inject a pre-configured {@link DynamoDbClient}. When provided, the
+         * {@link #region}, {@link #endpointUrl}, and {@link #credentialsProvider}
+         * settings are ignored.
+         */
+        public Builder dynamoDbClient(DynamoDbClient client) {
+            this.dynamoDbClient = client;
+            return this;
+        }
+
+        /** Build the {@link DynamoDBSaver}. */
+        public DynamoDBSaver build() {
+            requireNonNull(tableName, "'tableName' must not be null");
+            requireNonNull(stateSerializer, "'stateSerializer' must not be null");
+
+            if (dynamoDbClient == null) {
+                DynamoDbClientBuilder builder = DynamoDbClient.builder();
+
+                if (region != null) {
+                    builder.region(Region.of(region));
+                }
+                if (endpointUrl != null) {
+                    builder.endpointOverride(URI.create(endpointUrl));
+                }
+                builder.credentialsProvider(
+                    credentialsProvider != null ? credentialsProvider : DefaultCredentialsProvider.create()
+                );
+                dynamoDbClient = builder.build();
+            }
+
+            // dropTableFirst implies createTableIfNotExists
+            if (dropTableFirst) {
+                createTableIfNotExists = true;
+            }
+
+            return new DynamoDBSaver(this);
+        }
+    }
+
+    /** Factory method. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // ─── Fields ─────────────────────────────────────────────────────────────────
+
+    private final DynamoDbClient client;
+    private final DynamoDBRepository repository;
+    private final StateSerializer<? extends AgentState> stateSerializer;
+    private final boolean plainTextStateSerializerLegacyMode;
+
+    // ─── Constructor ─────────────────────────────────────────────────────────────
+
+    private DynamoDBSaver(Builder builder) {
+        this.client = builder.dynamoDbClient;
+        this.stateSerializer = builder.stateSerializer;
+        this.plainTextStateSerializerLegacyMode = builder.plainTextStateSerializerLegacyMode;
+
+        this.repository = new DynamoDBRepository(
+            this.client,
+            builder.tableName,
+            builder.ttlSeconds
+        );
+
+        // Table initialization
+        if (builder.dropTableFirst) {
+            log.debug("Dropping DynamoDB table '{}'", builder.tableName);
+            repository.dropTable();
+        }
+        if (builder.createTableIfNotExists) {
+            log.debug("Creating DynamoDB table '{}' (if not exists)", builder.tableName);
+            repository.createTableIfNotExists();
+        }
+    }
+
+    // ─── Serialization Helpers ───────────────────────────────────────────────────
+
+    /**
+     * Serialize the agent state map to Base64-encoded bytes (same pattern as PostgresSaver).
+     */
+    private byte[] encodeState(Map<String, Object> data) throws IOException {
+        final byte[] binaryData;
+        if (plainTextStateSerializerLegacyMode && stateSerializer instanceof PlainTextStateSerializer<?> ser) {
+            binaryData = ser.writeDataAsString(data).getBytes(StandardCharsets.UTF_8);
+        } else {
+            binaryData = stateSerializer.dataToBytes(data);
+        }
+        return binaryData;
+    }
+
+    /**
+     * Deserialize state bytes back to a {@code Map<String,Object>}.
+     */
+    private Map<String, Object> decodeState(byte[] payload, String contentType)
+            throws IOException, ClassNotFoundException {
+        if (!Objects.equals(contentType, stateSerializer.contentType())) {
+            throw new IllegalStateException(format(
+                "Content type used to store state '%s' differs from the deserializer's content type '%s'",
+                contentType, stateSerializer.contentType()
+            ));
+        }
+        if (plainTextStateSerializerLegacyMode && stateSerializer instanceof PlainTextStateSerializer<?> ser) {
+            return ser.readDataFromString(new String(payload, StandardCharsets.UTF_8));
+        }
+        return stateSerializer.dataFromBytes(payload);
+    }
+
+    // ─── AbstractCheckpointSaver template methods ────────────────────────────────
+
+    @Override
+    protected LinkedList<Checkpoint> loadCheckpoints(RunnableConfig config) throws Exception {
+        final String threadId = threadId(config);
+
+        // If this thread has been released, return empty (same semantics as PostgresSaver)
+        if (repository.isThreadReleased(threadId)) {
+            log.debug("Thread '{}' is released – returning empty checkpoint list", threadId);
+            return new LinkedList<>();
+        }
+
+        final LinkedList<Checkpoint> checkpoints = new LinkedList<>();
+        final List<DynamoDBRepository.CheckpointRecord> records = repository.loadCheckpointRecords(threadId);
+
+        for (DynamoDBRepository.CheckpointRecord record : records) {
+            try {
+                Map<String, Object> state = decodeState(record.payload(), record.contentType());
+                Checkpoint checkpoint = Checkpoint.builder()
+                    .id(record.checkpointId())
+                    .nodeId(record.nodeId())
+                    .nextNodeId(record.nextNodeId())
+                    .state(state)
+                    .build();
+                checkpoints.add(checkpoint);
+            } catch (Exception e) {
+                log.error("Failed to deserialize checkpoint '{}' for thread '{}' – skipping",
+                    record.checkpointId(), threadId, e);
+            }
+        }
+
+        log.debug("Loaded {} checkpoint(s) for thread '{}'", checkpoints.size(), threadId);
+        return checkpoints;
+    }
+
+    @Override
+    protected void insertedCheckpoint(RunnableConfig config,
+                                      LinkedList<Checkpoint> checkpoints,
+                                      Checkpoint checkpoint) throws Exception {
+        final String threadId = threadId(config);
+        log.debug("Inserting checkpoint '{}' for thread '{}'", checkpoint.getId(), threadId);
+
+        final byte[] payload = encodeState(checkpoint.getState());
+        repository.putCheckpoint(
+            threadId,
+            checkpoint.getId(),
+            checkpoint.getNodeId(),
+            checkpoint.getNextNodeId(),
+            payload,
+            stateSerializer.contentType()
+        );
+    }
+
+    @Override
+    protected void updatedCheckpoint(RunnableConfig config,
+                                     LinkedList<Checkpoint> checkpoints,
+                                     Checkpoint checkpoint) throws Exception {
+        final String threadId = threadId(config);
+
+        // Delete the old checkpoint (identified by the config's checkpointId) then insert new
+        config.checkPointId().ifPresent(oldId -> {
+            log.debug("Deleting old checkpoint '{}' before update, thread '{}'", oldId, threadId);
+            repository.deleteCheckpoint(threadId, oldId);
+        });
+
+        log.debug("Updating checkpoint '{}' for thread '{}'", checkpoint.getId(), threadId);
+        final byte[] payload = encodeState(checkpoint.getState());
+        repository.putCheckpoint(
+            threadId,
+            checkpoint.getId(),
+            checkpoint.getNodeId(),
+            checkpoint.getNextNodeId(),
+            payload,
+            stateSerializer.contentType()
+        );
+    }
+
+    @Override
+    protected Tag releaseCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints) throws Exception {
+        final String threadId = threadId(config);
+        log.debug("Releasing thread '{}'", threadId);
+        repository.markThreadReleased(threadId);
+        return new Tag(threadId, checkpoints);
+    }
+
+    /**
+     * Returns the underlying {@link DynamoDbClient} for advanced use-cases or testing.
+     */
+    public DynamoDbClient getDynamoDbClient() {
+        return client;
+    }
+}

--- a/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaverTest.java
+++ b/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaverTest.java
@@ -1,0 +1,387 @@
+package org.bsc.langgraph4j.checkpoint;
+
+import org.bsc.langgraph4j.CompileConfig;
+import org.bsc.langgraph4j.RunnableConfig;
+import org.bsc.langgraph4j.StateGraph;
+import org.bsc.langgraph4j.action.NodeAction;
+import org.bsc.langgraph4j.serializer.StateSerializer;
+import org.bsc.langgraph4j.serializer.plain_text.jackson.JacksonStateSerializer;
+import org.bsc.langgraph4j.serializer.std.ObjectStreamStateSerializer;
+import org.bsc.langgraph4j.state.AgentState;
+import org.bsc.langgraph4j.state.AgentStateFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.StreamSupport;
+import java.util.logging.LogManager;
+
+import static org.bsc.langgraph4j.StateGraph.END;
+import static org.bsc.langgraph4j.StateGraph.START;
+import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for {@link DynamoDBSaver} using DynamoDB Local via Testcontainers.
+ *
+ * <p>Each test method creates a fresh DynamoDB table (via {@code dropTableFirst=true}) so
+ * tests are fully isolated. The container is shared across all tests in the class for speed.
+ *
+ * <p>Run with:
+ * <pre>
+ *   mvn test -pl langgraph4j-dynamodb-saver -Dtest=DynamoDBSaverTest
+ * </pre>
+ */
+@Testcontainers
+public class DynamoDBSaverTest {
+
+    // ─── Serializer variants ─────────────────────────────────────────────────────
+
+    static class MyJacksonStateSerializer extends JacksonStateSerializer<AgentState> {
+        public MyJacksonStateSerializer(AgentStateFactory<AgentState> stateFactory) {
+            super(stateFactory);
+        }
+    }
+
+    public enum StateSerializerEnum {
+        BINARY(new ObjectStreamStateSerializer<>(AgentState::new)),
+        JSON(new MyJacksonStateSerializer(AgentState::new));
+
+        final StateSerializer<AgentState> stateSerializer;
+
+        StateSerializerEnum(StateSerializer<AgentState> stateSerializer) {
+            this.stateSerializer = stateSerializer;
+        }
+    }
+
+    // ─── Container setup ─────────────────────────────────────────────────────────
+
+    private static final int DYNAMODB_PORT = 8000;
+    private static final String TABLE_NAME = "lg4j-test-checkpoints";
+
+    @Container
+    static final FixedHostPortGenericContainer<?> dynamoContainer =
+        new FixedHostPortGenericContainer<>("amazon/dynamodb-local:latest")
+            .withFixedExposedPort(8344, DYNAMODB_PORT)
+            .waitingFor(Wait.forLogMessage(".*Initializing DynamoDB Local.*\\n", 1));
+
+    // ─── Lifecycle ───────────────────────────────────────────────────────────────
+
+    @BeforeAll
+    static void init() throws IOException {
+        try (var is = DynamoDBSaverTest.class.getResourceAsStream("/logging.properties")) {
+            if (is != null) {
+                LogManager.getLogManager().readConfiguration(is);
+            }
+        }
+        assertTrue(dynamoContainer.isRunning(), "DynamoDB Local container should be running");
+    }
+
+    @AfterAll
+    static void shutdown() {
+        dynamoContainer.close();
+    }
+
+    // ─── Saver factory ───────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link DynamoDBSaver} pointed at the test container.
+     * {@code dropTableFirst=true} ensures a clean table for every test.
+     */
+    DynamoDBSaver buildSaver(StateSerializerEnum param) {
+        String endpoint = "http://" + dynamoContainer.getHost()
+                        + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
+
+        return DynamoDBSaver.builder()
+            .tableName(TABLE_NAME)
+            .region("us-east-1")   // required by the SDK even for local DynamoDB
+            .endpointUrl(endpoint)
+            .credentialsProvider(  // DynamoDB Local accepts any non-null credentials
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create("dummy", "dummy")))
+            .stateSerializer(param.stateSerializer)
+            .dropTableFirst(true)
+            .build();
+    }
+
+    /**
+     * Builds a second saver that reuses the existing table (no drop).
+     * Used to verify that checkpoints survive across independent saver instances
+     * (i.e., they are truly persisted, not just held in memory).
+     */
+    DynamoDBSaver buildSaverReuse(StateSerializerEnum param) {
+        String endpoint = "http://" + dynamoContainer.getHost()
+                        + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
+
+        return DynamoDBSaver.builder()
+            .tableName(TABLE_NAME)
+            .region("us-east-1")
+            .endpointUrl(endpoint)
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create("dummy", "dummy")))
+            .stateSerializer(param.stateSerializer)
+            .createTableIfNotExists(false)  // table already exists
+            .build();
+    }
+
+    // ─── Test graph helper ───────────────────────────────────────────────────────
+
+    static StateGraph<AgentState> singleNodeGraph() throws Exception {
+        NodeAction<AgentState> agent1 = state -> Map.of("agent_1:prop1", "agent_1:test");
+        return new StateGraph<>(AgentState::new)
+            .addNode("agent_1", node_async(agent1))
+            .addEdge(START, "agent_1")
+            .addEdge("agent_1", END);
+    }
+
+    static StateGraph<AgentState> chatGraph() throws Exception {
+        NodeAction<AgentState> chatbot = state -> {
+            String userInput = (String) state.value("user_input").orElse("");
+            List<String> history = new ArrayList<>(state.value("history").map(v -> (List<String>) v).orElse(Collections.emptyList()));
+
+            history.add("User: " + userInput);
+
+            String aiResponse = "I don't know";
+            if (userInput.toLowerCase().contains("hi")) {
+                aiResponse = "Hi there";
+            } else if (userInput.toLowerCase().contains("weather")) {
+                aiResponse = "It is bright and sunny here in California";
+            }
+            history.add("AI: " + aiResponse);
+
+            return Map.of("history", history);
+        };
+
+        return new StateGraph<>(AgentState::new)
+                .addNode("chatbot", node_async(chatbot))
+                .addEdge(START, "chatbot")
+                .addEdge("chatbot", END);
+    }
+
+    // ─── Tests ───────────────────────────────────────────────────────────────────
+
+    /**
+     * After the graph runs with {@code releaseThread=true}, state history must be empty
+     * because the thread is marked as released and checkpoints are no longer returned.
+     */
+    @ParameterizedTest
+    @EnumSource(StateSerializerEnum.class)
+    void testCheckpointWithReleasedThread(StateSerializerEnum param) throws Exception {
+        var saver = buildSaver(param);
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(true)
+            .build();
+
+        var runnableConfig = RunnableConfig.builder().threadId("thread-released").build();
+        var workflow = singleNodeGraph().compile(compileConfig);
+
+        var result = workflow.invoke(Map.of("input", "test1"), runnableConfig);
+
+        assertTrue(result.isPresent(), "Workflow must produce a result");
+
+        var history = workflow.getStateHistory(runnableConfig);
+        assertTrue(history.isEmpty(), "History must be empty after thread is released");
+    }
+
+    /**
+     * Full lifecycle test: invoke graph, verify history, update state, reload via a fresh
+     * saver instance to confirm DynamoDB persistence (not just in-memory cache).
+     */
+    @ParameterizedTest
+    @EnumSource(StateSerializerEnum.class)
+    void testCheckpointWithNotReleasedThread(StateSerializerEnum param) throws Exception {
+        var saver = buildSaver(param);
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(false)
+            .build();
+
+        var runnableConfig = RunnableConfig.builder().threadId("thread-not-released").build();
+        var workflow = singleNodeGraph().compile(compileConfig);
+
+        // ── Step 1: invoke ──
+        var result = workflow.invoke(Map.of("input", "test1"), runnableConfig);
+        assertTrue(result.isPresent());
+
+        // ── Step 2: verify history ──
+        var history = workflow.getStateHistory(runnableConfig);
+        assertFalse(history.isEmpty());
+        assertEquals(2, history.size(), "Expected __START__ + agent_1 checkpoints");
+
+        // ── Step 3: inspect last snapshot ──
+        var lastSnapshot = workflow.lastStateOf(runnableConfig);
+        assertTrue(lastSnapshot.isPresent());
+        assertEquals("agent_1", lastSnapshot.get().node());
+        assertEquals(END, lastSnapshot.get().next());
+
+        // ── Step 4: updateState round-trip ──
+        var updatedConfig = workflow.updateState(
+            lastSnapshot.get().config(), Map.of("update", "update test"));
+
+        var updatedSnapshot = workflow.stateOf(updatedConfig);
+        assertTrue(updatedSnapshot.isPresent());
+        assertEquals("agent_1", updatedSnapshot.get().node());
+        assertTrue(updatedSnapshot.get().state().value("update").isPresent());
+        assertEquals("update test", updatedSnapshot.get().state().value("update").get());
+        assertEquals(END, lastSnapshot.get().next());
+
+        // ── Step 5: fresh saver reloads from DynamoDB ──
+        var saver2 = buildSaverReuse(param);
+        var workflow2 = singleNodeGraph().compile(
+            CompileConfig.builder().checkpointSaver(saver2).releaseThread(false).build());
+
+        var history2 = workflow2.getStateHistory(runnableConfig);
+        assertFalse(history2.isEmpty());
+        assertEquals(2, history2.size(), "Fresh saver instance must reload same checkpoints");
+
+        var reloadedSnapshot = workflow2.stateOf(updatedConfig);
+        assertTrue(reloadedSnapshot.isPresent());
+        assertEquals("agent_1", reloadedSnapshot.get().node());
+        assertEquals(END, reloadedSnapshot.get().next());
+        assertTrue(reloadedSnapshot.get().state().value("update").isPresent());
+        assertEquals("update test", reloadedSnapshot.get().state().value("update").get());
+
+        saver2.release(runnableConfig);
+    }
+
+    @ParameterizedTest
+    @EnumSource(StateSerializerEnum.class)
+    void testMultiTurnChatbot(StateSerializerEnum param) throws Exception {
+        var saver = buildSaver(param);
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(false)
+            .build();
+
+        var runnableConfig = RunnableConfig.builder().threadId("thread-chatbot").build();
+        var workflow = chatGraph().compile(compileConfig);
+
+        // --- Turn 1: "Hi" ---
+        workflow.invoke(Map.of("user_input", "Hi"), runnableConfig);
+
+        var state1 = workflow.lastStateOf(runnableConfig).orElseThrow();
+        List<String> history1 = (List<String>) state1.state().value("history").orElseThrow();
+        assertEquals(2, history1.size());
+        assertEquals("User: Hi", history1.get(0));
+        assertEquals("AI: Hi there", history1.get(1));
+
+        // --- Turn 2: "how's the weather" ---
+        workflow.invoke(Map.of("user_input", "how's the weather"), runnableConfig);
+
+        var state2 = workflow.lastStateOf(runnableConfig).orElseThrow();
+        List<String> history2 = (List<String>) state2.state().value("history").orElseThrow();
+        assertEquals(4, history2.size());
+        // Verify accumulation
+        assertEquals("User: Hi", history2.get(0));
+        assertEquals("AI: Hi there", history2.get(1));
+        assertEquals("User: how's the weather", history2.get(2));
+        assertEquals("AI: It is bright and sunny here in California", history2.get(3));
+
+        // Verify history depth (2 turns * 2 nodes per turn = 4 checkpoints)
+        var fullHistory = workflow.getStateHistory(runnableConfig);
+        assertEquals(4, StreamSupport.stream(fullHistory.spliterator(), false).count());
+
+        saver.release(runnableConfig);
+    }
+
+    /**
+     * Verify that a saver configured with a TTL still writes and reads checkpoints correctly
+     * within the TTL window.
+     */
+    @Test
+    void testWithTTL() throws Exception {
+        String endpoint = "http://" + dynamoContainer.getHost()
+                        + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
+
+        var saver = DynamoDBSaver.builder()
+            .tableName(TABLE_NAME)
+            .region("us-east-1")
+            .endpointUrl(endpoint)
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("dummy", "dummy")))
+            .stateSerializer(new ObjectStreamStateSerializer<>(AgentState::new))
+            .dropTableFirst(true)
+            .ttlSeconds(3600) // 1 hour — items will be available throughout the test
+            .build();
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(false)
+            .build();
+
+        var runnableConfig = RunnableConfig.builder().threadId("thread-ttl").build();
+        var workflow = singleNodeGraph().compile(compileConfig);
+
+        var result = workflow.invoke(Map.of("input", "ttl-test"), runnableConfig);
+        assertTrue(result.isPresent(), "Workflow must produce a result with TTL enabled");
+
+        var history = workflow.getStateHistory(runnableConfig);
+        assertFalse(history.isEmpty(), "Checkpoints must be readable within the TTL window");
+        assertEquals(2, history.size());
+
+        saver.release(runnableConfig);
+    }
+
+    /**
+     * Verify that a pre-built {@link software.amazon.awssdk.services.dynamodb.DynamoDbClient}
+     * injected via {@code .dynamoDbClient(...)} works correctly (e.g. for shared clients
+     * managed by the application container).
+     */
+    @Test
+    void testWithInjectedDynamoDbClient() throws Exception {
+        String endpoint = "http://" + dynamoContainer.getHost()
+                        + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
+
+        // Build the client externally
+        var externalClient = software.amazon.awssdk.services.dynamodb.DynamoDbClient.builder()
+            .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+            .endpointOverride(java.net.URI.create(endpoint))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("dummy", "dummy")))
+            .build();
+
+        var saver = DynamoDBSaver.builder()
+            .tableName(TABLE_NAME)
+            .stateSerializer(new ObjectStreamStateSerializer<>(AgentState::new))
+            .dynamoDbClient(externalClient)  // inject — region/endpoint settings ignored
+            .dropTableFirst(true)
+            .build();
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(false)
+            .build();
+
+        var runnableConfig = RunnableConfig.builder().threadId("thread-injected-client").build();
+        var workflow = singleNodeGraph().compile(compileConfig);
+
+        var result = workflow.invoke(Map.of("input", "injected-client"), runnableConfig);
+        assertTrue(result.isPresent());
+
+        var history = workflow.getStateHistory(runnableConfig);
+        assertFalse(history.isEmpty(), "Checkpoints must persist with injected client");
+        assertEquals(2, history.size());
+
+        saver.release(runnableConfig);
+
+        // Caller is responsible for closing the externally managed client
+        externalClient.close();
+    }
+}

--- a/langgraph4j-dynamodb-saver/src/test/resources/logging.properties
+++ b/langgraph4j-dynamodb-saver/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+# Default logging level
+.level = SEVERE
+
+# Handlers
+handlers = java.util.logging.ConsoleHandler
+
+# ConsoleHandler configuration
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Compact format: message + exception only
+java.util.logging.SimpleFormatter.format=%5$s %6$s%n
+
+# Enable detailed logging for langgraph4j internals during tests
+org.bsc.langgraph4j.level = FINEST

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,7 @@
         <module>langgraph4j-oracle-saver</module>
         <module>langgraph4j-mysql-saver</module>
         <module>langgraph4j-redis-saver</module>
+        <module>langgraph4j-dynamodb-saver</module>
 
         <module>langgraph4j-opentelemetry</module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <langchain4j.version>1.13.0</langchain4j.version>
-        <langchain4j.beta>1.13.0-beta23</langchain4j.beta>
-        <!-- back port spring-ai to version 1.0.0 from 1.1.2 due to the following bug: https://github.com/spring-projects/spring-ai/issues/5196 -->
+        <langchain4j.version>1.14.1</langchain4j.version>
+        <langchain4j.beta>1.14.1-beta24</langchain4j.beta>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
     </properties>


### PR DESCRIPTION
# feat: add DynamoDB-based checkpoint saver implementation

## Description
This PR introduces the `langgraph4j-dynamodb-saver` module, providing a robust, production-ready checkpoint saver implementation using Amazon DynamoDB. This allows LangGraph4j agents to persist state in a scalable, serverless NoSQL environment.

## Key Features
*   **Optimized Single-Table Design**: Implements a composite primary key strategy (`PK` + `SK`) for efficient querying and state management.
*   **State Chunking**: To bypass DynamoDB's 400KB item limit, the implementation automatically splits checkpoint metadata and large serialized state payloads into separate items (`CHECKPOINT` vs `CHUNK`).
*   **Automatic TTL Support**: Built-in support for DynamoDB's Time-To-Live (TTL) feature, allowing for automatic expiration and cleanup of old checkpoints to manage storage costs.
*   **Thread Lifecycle Management**: Implements a sentinel marker system to handle "released" (archived) threads, ensuring consistency with the existing `PostgresSaver` semantics.
*   **Flexible Configuration**: Features a fluent `Builder` for `DynamoDBSaver` that supports:
    *   Custom AWS Regions and Credentials Providers.
    *   Endpoint overrides (for local development with `dynamodb-local` or LocalStack).
    *   Optional table auto-provisioning (`createTableIfNotExists`).
    *   Compatibility modes for different state serializers.

## Components Added
- **`DynamoDBSaver`**: The primary implementation of `AbstractCheckpointSaver`.
- **`DynamoDBRepository`**: A dedicated data access layer handling low-level DynamoDB SDK interactions.
- **`DynamoDBSaverTest`**: A comprehensive test suite covering table lifecycle, checkpoint persistence, chronological retrieval, and state recovery.

## Example Usage
```java
DynamoDBSaver saver = DynamoDBSaver.builder()
    .tableName("agent-checkpoints")
    .region("us-east-1")
    .stateSerializer(new ObjectStreamStateSerializer<>(AgentState::new))
    .createTableIfNotExists(true)
    .ttlSeconds(3600 * 24 * 7) // 7 days retention
    .build();
