### PR TITLE
Add support for additional conenction properties in Builder

### DIFF
--- a/langgraph4j-postgres-saver/src/main/java/org/bsc/langgraph4j/checkpoint/PostgresSaver.java
+++ b/langgraph4j-postgres-saver/src/main/java/org/bsc/langgraph4j/checkpoint/PostgresSaver.java
@@ -31,6 +31,7 @@ public class PostgresSaver extends AbstractCheckpointSaver {
         private boolean dropTablesFirst;
         private DataSource datasource;
         private boolean plainTextStateSerializerLegacyMode = false;
+        private final Properties additionalProperties = new Properties();
 
         public <State extends AgentState> Builder stateSerializer(StateSerializer<State> stateSerializer) {
             this.stateSerializer = stateSerializer;
@@ -79,6 +80,16 @@ public class PostgresSaver extends AbstractCheckpointSaver {
             return this;
         }
 
+        public Builder property(String name, String value) {
+            this.additionalProperties.setProperty(name, value);
+            return this;
+        }
+
+        public Builder properties(Properties properties) {
+            this.additionalProperties.putAll(properties);
+            return this;
+        }
+
         public Builder createTables(boolean createTables) {
             this.createTables = createTables;
             return this;
@@ -110,6 +121,9 @@ public class PostgresSaver extends AbstractCheckpointSaver {
                 ds.setPassword(requireNonNull(password, "password cannot be null"));
                 ds.setPortNumbers( new int[] {port} );
                 ds.setServerNames( new String[] { requireNotBlank(host, "host") } );
+                for (var entry : additionalProperties.entrySet()) {
+                    ds.setProperty(entry.getKey().toString(), entry.getValue().toString());
+                }
                 datasource = ds;
             }
 

--- a/langgraph4j-postgres-saver/src/test/java/org/bsc/langgraph4j/checkpoint/PostgresSaverTest.java
+++ b/langgraph4j-postgres-saver/src/test/java/org/bsc/langgraph4j/checkpoint/PostgresSaverTest.java
@@ -11,6 +11,7 @@ import org.bsc.langgraph4j.state.AgentState;
 import org.bsc.langgraph4j.state.AgentStateFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.postgresql.ds.PGSimpleDataSource;
@@ -19,6 +20,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.Properties;
 import java.util.logging.LogManager;
 
 import static org.bsc.langgraph4j.StateGraph.END;
@@ -234,6 +236,56 @@ public class PostgresSaverTest {
 
         saver.release( runnableConfig );
 
+    }
+
+    @Test
+    public void testBuilderSinglePropertyApplied() throws Exception {
+        var saver = buildPostgresSaver()
+                .property("ApplicationName", "lg4j-property-test")
+                .createTables(false)
+                .stateSerializer(StateSerializerEnum.BINARY.stateSerializer)
+                .build();
+
+        try (var conn = saver.datasource.getConnection();
+             var rs = conn.createStatement().executeQuery("SELECT current_setting('application_name')")) {
+            assertTrue(rs.next());
+            assertEquals("lg4j-property-test", rs.getString(1));
+        }
+    }
+
+    @Test
+    public void testBuilderMultiplePropertiesApplied() throws Exception {
+        var props = new Properties();
+        props.setProperty("ApplicationName", "lg4j-props-test");
+        props.setProperty("connectTimeout", "30");
+
+        var saver = buildPostgresSaver()
+                .properties(props)
+                .createTables(false)
+                .stateSerializer(StateSerializerEnum.BINARY.stateSerializer)
+                .build();
+
+        try (var conn = saver.datasource.getConnection();
+             var rs = conn.createStatement().executeQuery("SELECT current_setting('application_name')")) {
+            assertTrue(rs.next());
+            assertEquals("lg4j-props-test", rs.getString(1));
+        }
+    }
+
+    @Test
+    public void testBuilderPropertyIgnoredWithExternalDatasource() throws Exception {
+        // when datasource() is provided explicitly, property()/properties() have no effect
+        var saver = buildPostgresSaverWithExistedDatasource()
+                .property("ApplicationName", "should-not-apply")
+                .createTables(false)
+                .stateSerializer(StateSerializerEnum.BINARY.stateSerializer)
+                .build();
+
+        try (var conn = saver.datasource.getConnection();
+             var rs = conn.createStatement().executeQuery("SELECT current_setting('application_name')")) {
+            assertTrue(rs.next());
+            assertNotEquals("should-not-apply", rs.getString(1));
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem
  
  `PostgresSaver.Builder` only exposed fixed setters for standard connection
  parameters. Any additional PostgreSQL property — SSL, replication flags,
  timeouts, etc. — was unreachable, forcing users to construct a
  `PGSimpleDataSource` manually and pass it via `.datasource(ds)`.

  ## Solution

  Added `property(String, String)` and `properties(Properties)` to the builder.
  Internally they delegate to `BaseDataSource.setProperty()`, which handles
  both known `PGProperty` names and arbitrary string keys. Properties are
  intentionally ignored when an external datasource is provided via `.datasource(ds)`.

  Three tests cover the new behaviour: single property, bulk injection,
  and the external-datasource contract.