### PR TITLE
Implement StorageStrategy for DynamoDB and S3 integration

### DIFF
--- a/langgraph4j-dynamodb-saver/pom.xml
+++ b/langgraph4j-dynamodb-saver/pom.xml
@@ -57,6 +57,14 @@
             <version>${aws.sdk.version}</version>
         </dependency>
 
+        <!-- AWS SDK v2 – S3 (optional, for large-payload offloading) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${aws.sdk.version}</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- AWS SDK v2 – URL Connection HTTP client (lightweight, no Netty) -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -102,6 +110,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>minio</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBRepository.java
+++ b/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBRepository.java
@@ -15,15 +15,21 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
 import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
 import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
 /**
  * Low-level DynamoDB operations for the {@link DynamoDBSaver}.
@@ -46,6 +52,9 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
  * <li>{@code nodeId} – current node name</li>
  * <li>{@code nextNodeId} – next node name</li>
  * <li>{@code contentType} – serializer content-type string</li>
+ * <li>{@code parentCheckpointId} – optional; checkpoint ID of the parent (lineage)</li>
+ * <li>{@code ref_loc} – storage location: {@code "DYNAMODB"} or {@code "S3"} (future)</li>
+ * <li>{@code ref_key} – reference key for payload retrieval</li>
  * <li>{@code payload} – binary; only present in CHUNK items</li>
  * <li>{@code ttl} – optional epoch-second number for DynamoDB TTL</li>
  * </ul>
@@ -53,6 +62,15 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 class DynamoDBRepository {
 
     private static final Logger log = LoggerFactory.getLogger(DynamoDBRepository.class);
+
+    /** Maximum number of items per {@code batchWriteItem} request. */
+    private static final int BATCH_WRITE_MAX_ITEMS = 25;
+
+    /** Maximum retry rounds for unprocessed items in batch operations. */
+    private static final int BATCH_RETRY_MAX_ROUNDS = 3;
+
+    /** Backoff delay in milliseconds between batch retry rounds. */
+    private static final long BATCH_RETRY_BACKOFF_MS = 100;
 
     // ─── PK/SK generators ───────────────────────────────────────────────────────
     static String checkpointPK(String threadId) {
@@ -82,6 +100,17 @@ class DynamoDBRepository {
     // ─── Record type returned to DynamoDBSaver ──────────────────────────────────
     /**
      * Immutable view of a checkpoint as loaded from DynamoDB.
+     *
+     * @param threadId thread identifier
+     * @param checkpointId UUID of this checkpoint
+     * @param nodeId current graph node
+     * @param nextNodeId next graph node
+     * @param payload serialized state bytes
+     * @param contentType serializer content-type string
+     * @param savedAt epoch-millis timestamp when the checkpoint was persisted
+     * @param parentCheckpointId checkpoint ID of the parent (nullable for the first checkpoint)
+     * @param refLoc storage location of the payload ({@code "DYNAMODB"} or {@code "S3"})
+     * @param refKey reference key used to retrieve the payload from its storage location
      */
     record CheckpointRecord(
             String threadId,
@@ -90,7 +119,10 @@ class DynamoDBRepository {
             String nextNodeId,
             byte[] payload,
             String contentType,
-            Long savedAt
+            Long savedAt,
+            String parentCheckpointId,
+            String refLoc,
+            String refKey
             ) {
 
     }
@@ -99,12 +131,15 @@ class DynamoDBRepository {
     private final DynamoDbClient client;
     private final String tableName;
     private final Long ttlSeconds;
+    private final StorageStrategy storageStrategy;
 
     // ─── Constructor ─────────────────────────────────────────────────────────────
-    DynamoDBRepository(DynamoDbClient client, String tableName, Long ttlSeconds) {
+    DynamoDBRepository(DynamoDbClient client, String tableName, Long ttlSeconds,
+                       StorageStrategy storageStrategy) {
         this.client = client;
         this.tableName = tableName;
         this.ttlSeconds = ttlSeconds;
+        this.storageStrategy = storageStrategy;
     }
 
     // ─── Table lifecycle ─────────────────────────────────────────────────────────
@@ -167,15 +202,26 @@ class DynamoDBRepository {
      * @param nextNodeId next graph node
      * @param payload serialized state bytes
      * @param contentType serializer content-type string
+     * @param parentCheckpointId checkpoint ID of the parent for lineage tracking (nullable)
+     * @param allowOverwrite if false, insert-only (conditional write); if true, overwrite allowed
      */
     void putCheckpoint(String threadId,
             String checkpointId,
             String nodeId,
             String nextNodeId,
             byte[] payload,
-            String contentType) {
+            String contentType,
+            String parentCheckpointId,
+            boolean allowOverwrite) {
 
-        // ── 1. Metadata item ──────────────────────────────────────────────────
+        String chunkKey = chunkPK(threadId, checkpointId);
+        String s3Key = threadId + "/checkpoints/" + checkpointId;
+
+        // ── 1. Store payload via StorageStrategy ──────────────────────────────
+        String refLoc = storageStrategy.storeData(chunkKey, s3Key, payload, allowOverwrite);
+        String refKey = "S3".equals(refLoc) ? s3Key : chunkKey;
+
+        // ── 2. Metadata item ──────────────────────────────────────────────────
         Map<String, AttributeValue> metaItem = new HashMap<>();
         metaItem.put("PK", s(checkpointPK(threadId)));
         metaItem.put("SK", s(checkpointSK(checkpointId)));
@@ -184,27 +230,37 @@ class DynamoDBRepository {
         metaItem.put("nextNodeId", s(nextNodeId));
         metaItem.put("contentType", s(contentType));
         metaItem.put("savedAt", n(Instant.now().toEpochMilli()));
+        metaItem.put("ref_loc", s(refLoc));
+        metaItem.put("ref_key", s(refKey));
+
+        if (parentCheckpointId != null) {
+            metaItem.put("parentCheckpointId", s(parentCheckpointId));
+        }
 
         if (ttlSeconds != null) {
             metaItem.put("ttl", n(Instant.now().getEpochSecond() + ttlSeconds));
         }
 
-        client.putItem(r -> r.tableName(tableName).item(metaItem));
-        log.debug("Stored checkpoint metadata: threadId={}, checkpointId={}", threadId, checkpointId);
+        PutItemRequest.Builder metaReqBuilder = PutItemRequest.builder()
+                .tableName(tableName)
+                .item(metaItem);
 
-        // ── 2. Payload chunk item ─────────────────────────────────────────────
-        Map<String, AttributeValue> chunkItem = new HashMap<>();
-        chunkItem.put("PK", s(chunkPK(threadId, checkpointId)));
-        chunkItem.put("SK", s(chunkSK()));
-        chunkItem.put("payload", b(payload));
-
-        if (ttlSeconds != null) {
-            chunkItem.put("ttl", n(Instant.now().getEpochSecond() + ttlSeconds));
+        if (!allowOverwrite) {
+            metaReqBuilder.conditionExpression("attribute_not_exists(PK)");
         }
 
-        client.putItem(r -> r.tableName(tableName).item(chunkItem));
-        log.debug("Stored payload chunk: threadId={}, checkpointId={}, size={}B",
-                threadId, checkpointId, payload.length);
+        try {
+            client.putItem(metaReqBuilder.build());
+        } catch (ConditionalCheckFailedException e) {
+            if (!allowOverwrite) {
+                log.debug("Checkpoint metadata already exists, skipping: checkpointId={}", checkpointId);
+                return;
+            }
+            throw e;
+        }
+
+        log.debug("Stored checkpoint metadata: threadId={}, checkpointId={}, parentCheckpointId={}, ref_loc={}",
+                threadId, checkpointId, parentCheckpointId, refLoc);
     }
 
     /**
@@ -247,15 +303,26 @@ class DynamoDBRepository {
                 String contentType = item.get("contentType").s();
                 Long savedAt = item.containsKey("savedAt") ? Long.parseLong(item.get("savedAt").n()) : 0L;
 
-                // Fetch payload from chunk item
-                byte[] payload = loadChunkPayload(threadId, checkpointId);
+                // Read lineage + storage location with backward compat guards
+                String parentCpId = item.containsKey("parentCheckpointId")
+                        ? item.get("parentCheckpointId").s() : null;
+                String refLoc = item.containsKey("ref_loc")
+                        ? item.get("ref_loc").s() : "DYNAMODB";
+                String refKey = item.containsKey("ref_key")
+                        ? item.get("ref_key").s() : chunkPK(threadId, checkpointId);
+
+                // Fetch payload from storage backend
+                byte[] payload = storageStrategy.retrieveData(refKey, refLoc);
                 if (payload == null) {
-                    log.warn("Payload chunk not found for checkpointId='{}', thread='{}' – skipping",
-                            checkpointId, threadId);
+                    log.warn("Payload not found for checkpointId='{}', thread='{}', ref_loc='{}', ref_key='{}' – skipping",
+                            checkpointId, threadId, refLoc, refKey);
                     continue;
                 }
 
-                records.add(new CheckpointRecord(threadId, checkpointId, nodeId, nextNodeId, payload, contentType, savedAt));
+                records.add(new CheckpointRecord(
+                        threadId, checkpointId, nodeId, nextNodeId,
+                        payload, contentType, savedAt,
+                        parentCpId, refLoc, refKey));
             }
 
             exclusiveStartKey = response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null;
@@ -268,37 +335,23 @@ class DynamoDBRepository {
     }
 
     /**
-     * Fetches the serialized payload for a single checkpoint from its chunk
-     * item.
+     * Fetches the serialized payload for a single checkpoint using the
+     * {@link StorageStrategy}.
      *
+     * @param refKey the reference key for the payload
+     * @param refLoc the storage location ({@code "DYNAMODB"} or {@code "S3"})
      * @return the raw bytes, or {@code null} if the item is not found
      */
-    byte[] loadChunkPayload(String threadId, String checkpointId) {
-        GetItemResponse response = client.getItem(r -> r
-                .tableName(tableName)
-                .key(Map.of(
-                        "PK", s(chunkPK(threadId, checkpointId)),
-                        "SK", s(chunkSK())
-                ))
-                .projectionExpression("payload")
-        );
-
-        if (!response.hasItem() || !response.item().containsKey("payload")) {
-            return null;
-        }
-
-        return response.item().get("payload").b().asByteArray();
+    byte[] loadChunkPayload(String refKey, String refLoc) {
+        return storageStrategy.retrieveData(refKey, refLoc);
     }
 
     /**
-     * Deletes the checkpoint metadata item and its associated payload chunk
-     * item.
-     *
-     * @param threadId thread identifier
-     * @param checkpointId UUID of the checkpoint to delete
+     * Deletes a single checkpoint: its metadata item. Payload cleanup is
+     * handled by the {@link StorageStrategy} during {@code deleteThread}.
      */
     void deleteCheckpoint(String threadId, String checkpointId) {
-        // Delete metadata item
+        // Delete metadata
         client.deleteItem(r -> r
                 .tableName(tableName)
                 .key(Map.of(
@@ -307,7 +360,7 @@ class DynamoDBRepository {
                 ))
         );
 
-        // Delete chunk item
+        // Delete DynamoDB chunk (best effort — may not exist if S3)
         client.deleteItem(r -> r
                 .tableName(tableName)
                 .key(Map.of(
@@ -352,6 +405,171 @@ class DynamoDBRepository {
                 .projectionExpression("PK")
         );
         return response.hasItem();
+    }
+
+    // ─── Hard delete operations ──────────────────────────────────────────────────
+    /**
+     * Deletes all items associated with a thread: checkpoint metadata items,
+     * payload chunk items, and the released sentinel (if present).
+     *
+     * <p>This is a <em>hard delete</em> — all data for the thread is permanently
+     * removed from DynamoDB. The operation is idempotent: calling it on a
+     * non-existent or already-deleted thread is a no-op.
+     *
+     * @param threadId thread identifier to delete
+     */
+    void deleteThread(String threadId) {
+        // ── 1. Query all checkpoint metadata items to collect checkpoint IDs + ref info ──
+        String pk = checkpointPK(threadId);
+        List<String> checkpointIds = new ArrayList<>();
+        List<String[]> payloadRefs = new ArrayList<>();  // [refKey, refLoc]
+
+        QueryRequest query = QueryRequest.builder()
+                .tableName(tableName)
+                .keyConditionExpression("PK = :pk")
+                .expressionAttributeValues(Map.of(":pk", s(pk)))
+                .projectionExpression("SK, ref_loc, ref_key")
+                .build();
+
+        Map<String, AttributeValue> exclusiveStartKey = null;
+        do {
+            QueryRequest.Builder reqBuilder = query.toBuilder();
+            if (exclusiveStartKey != null) {
+                reqBuilder.exclusiveStartKey(exclusiveStartKey);
+            }
+            QueryResponse response = client.query(reqBuilder.build());
+            for (Map<String, AttributeValue> item : response.items()) {
+                String cpId = item.get("SK").s();
+                checkpointIds.add(cpId);
+
+                // Collect ref info for S3 cleanup
+                String refLoc = item.containsKey("ref_loc") ? item.get("ref_loc").s() : "DYNAMODB";
+                String refKey = item.containsKey("ref_key") ? item.get("ref_key").s() : chunkPK(threadId, cpId);
+                payloadRefs.add(new String[]{refKey, refLoc});
+            }
+            exclusiveStartKey = response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null;
+        } while (exclusiveStartKey != null);
+
+        if (checkpointIds.isEmpty()) {
+            log.debug("No checkpoints found for thread '{}' – nothing to delete", threadId);
+            deleteReleasedMarker(threadId);
+            return;
+        }
+
+        // ── 2. Build list of DynamoDB keys to delete (metadata items only) ───
+        List<Map<String, AttributeValue>> keysToDelete = new ArrayList<>();
+
+        for (String checkpointId : checkpointIds) {
+            // Checkpoint metadata item
+            keysToDelete.add(Map.of(
+                    "PK", s(checkpointPK(threadId)),
+                    "SK", s(checkpointSK(checkpointId))
+            ));
+        }
+
+        // Released marker
+        keysToDelete.add(Map.of(
+                "PK", s(releasedPK(threadId)),
+                "SK", s(releasedSK())
+        ));
+
+        // ── 3. Batch delete metadata items from DynamoDB ─────────────────────
+        batchDeleteItems(keysToDelete);
+
+        // ── 4. Delete payloads via StorageStrategy (handles both DynamoDB chunks + S3) ──
+        storageStrategy.batchDeleteData(payloadRefs);
+
+        log.info("Deleted thread '{}': {} checkpoint(s)",
+                threadId, checkpointIds.size());
+    }
+
+    /**
+     * Deletes the released sentinel marker for a thread, if it exists.
+     *
+     * @param threadId thread identifier
+     */
+    private void deleteReleasedMarker(String threadId) {
+        client.deleteItem(r -> r
+                .tableName(tableName)
+                .key(Map.of(
+                        "PK", s(releasedPK(threadId)),
+                        "SK", s(releasedSK())
+                ))
+        );
+    }
+
+    // ─── Batch operations ────────────────────────────────────────────────────────
+    /**
+     * Batch-deletes items from DynamoDB using {@code batchWriteItem}.
+     *
+     * <p>Items are partitioned into batches of {@value #BATCH_WRITE_MAX_ITEMS}
+     * (the DynamoDB maximum per request). Unprocessed items are retried up to
+     * {@value #BATCH_RETRY_MAX_ROUNDS} times with a {@value #BATCH_RETRY_BACKOFF_MS}ms
+     * backoff between rounds.
+     *
+     * @param keys list of composite keys ({@code PK} + {@code SK}) to delete
+     */
+    void batchDeleteItems(List<Map<String, AttributeValue>> keys) {
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        for (int i = 0; i < keys.size(); i += BATCH_WRITE_MAX_ITEMS) {
+            int end = Math.min(i + BATCH_WRITE_MAX_ITEMS, keys.size());
+            List<Map<String, AttributeValue>> batch = keys.subList(i, end);
+
+            List<WriteRequest> deleteRequests = batch.stream()
+                    .map(key -> WriteRequest.builder()
+                            .deleteRequest(DeleteRequest.builder().key(key).build())
+                            .build())
+                    .toList();
+
+            Map<String, List<WriteRequest>> requestItems = Map.of(tableName, deleteRequests);
+            processBatchWithRetry(requestItems, batch.size());
+        }
+    }
+
+    private void processBatchWithRetry(Map<String, List<WriteRequest>> initialRequestItems, int batchSize) {
+        Map<String, List<WriteRequest>> requestItems = initialRequestItems;
+        int retryRound = 0;
+
+        while (!requestItems.isEmpty() && retryRound <= BATCH_RETRY_MAX_ROUNDS) {
+            BatchWriteItemRequest request = BatchWriteItemRequest.builder()
+                    .requestItems(requestItems)
+                    .build();
+
+            BatchWriteItemResponse response = client.batchWriteItem(request);
+
+            if (!response.hasUnprocessedItems() || response.unprocessedItems().isEmpty()) {
+                log.debug("Batch deleted {} item(s) successfully", batchSize);
+                return;
+            }
+
+            requestItems = response.unprocessedItems();
+            retryRound++;
+
+            int unprocessedCount = requestItems.values().stream().mapToInt(List::size).sum();
+            log.debug("Batch delete: {} unprocessed item(s), retry round {}/{}",
+                    unprocessedCount, retryRound, BATCH_RETRY_MAX_ROUNDS);
+
+            if (retryRound <= BATCH_RETRY_MAX_ROUNDS) {
+                sleepForBackoff(retryRound);
+            }
+        }
+
+        int unprocessedCount = requestItems.values().stream().mapToInt(List::size).sum();
+        log.warn("Batch delete: {} item(s) still unprocessed after {} retries",
+                unprocessedCount, BATCH_RETRY_MAX_ROUNDS);
+    }
+
+    private void sleepForBackoff(int retryRound) {
+        try {
+            long backoffMs = BATCH_RETRY_BACKOFF_MS * (1L << (retryRound - 1));
+            Thread.sleep(backoffMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted during batch delete backoff", e);
+        }
     }
 
     // ─── AttributeValue helpers ──────────────────────────────────────────────────

--- a/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaver.java
+++ b/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaver.java
@@ -8,9 +8,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
 import java.io.IOException;
 import java.net.URI;
@@ -81,6 +88,11 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
         private boolean dropTableFirst = false;
         /** Inject a fully configured client (useful for tests or shared clients). */
         private DynamoDbClient dynamoDbClient;
+        private String s3Bucket;
+        private String s3KeyPrefix;
+        private String s3EndpointUrl;
+        /** Inject a pre-configured S3 client. */
+        private S3Client s3Client;
 
         Builder() {}
 
@@ -170,6 +182,42 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
             return this;
         }
 
+        /**
+         * S3 bucket name for large-payload offloading. When set (along with
+         * {@link #region}), payloads exceeding 350KB are automatically stored
+         * in S3 instead of DynamoDB.
+         */
+        public Builder s3Bucket(String s3Bucket) {
+            this.s3Bucket = s3Bucket;
+            return this;
+        }
+
+        /**
+         * Optional prefix prepended to all S3 keys. Useful for bucket-level
+         * isolation between environments or applications.
+         */
+        public Builder s3KeyPrefix(String s3KeyPrefix) {
+            this.s3KeyPrefix = s3KeyPrefix;
+            return this;
+        }
+
+        /**
+         * Override the S3 service endpoint URL. Useful for MinIO or LocalStack.
+         */
+        public Builder s3EndpointUrl(String s3EndpointUrl) {
+            this.s3EndpointUrl = s3EndpointUrl;
+            return this;
+        }
+
+        /**
+         * Inject a pre-configured {@link S3Client}. When provided, the S3 client
+         * is not built internally.
+         */
+        public Builder s3Client(S3Client s3Client) {
+            this.s3Client = s3Client;
+            return this;
+        }
+
         /** Build the {@link DynamoDBSaver}. */
         public DynamoDBSaver build() {
             requireNonNull(tableName, "'tableName' must not be null");
@@ -187,7 +235,34 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
                 builder.credentialsProvider(
                     credentialsProvider != null ? credentialsProvider : DefaultCredentialsProvider.create()
                 );
+
+                // User-agent + adaptive retry for observability and resilience
+                ClientOverrideConfiguration overrideConfig = ClientOverrideConfiguration.builder()
+                    .putAdvancedOption(
+                        SdkAdvancedClientOption.USER_AGENT_SUFFIX,
+                        "x-client-framework:langgraph4j-dynamodb")
+                    .retryStrategy(RetryMode.ADAPTIVE)
+                    .build();
+                builder.overrideConfiguration(overrideConfig);
+
                 dynamoDbClient = builder.build();
+            }
+
+            // Build S3 client if bucket is configured
+            if (s3Client == null && s3Bucket != null) {
+                S3ClientBuilder s3Builder = S3Client.builder()
+                    .forcePathStyle(true);
+
+                if (region != null) {
+                    s3Builder.region(Region.of(region));
+                }
+                if (s3EndpointUrl != null) {
+                    s3Builder.endpointOverride(URI.create(s3EndpointUrl));
+                }
+                s3Builder.credentialsProvider(
+                    credentialsProvider != null ? credentialsProvider : DefaultCredentialsProvider.create()
+                );
+                s3Client = s3Builder.build();
             }
 
             // dropTableFirst implies createTableIfNotExists
@@ -218,10 +293,21 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
         this.stateSerializer = builder.stateSerializer;
         this.plainTextStateSerializerLegacyMode = builder.plainTextStateSerializerLegacyMode;
 
+        // Create StorageStrategy for payload routing (DynamoDB vs S3)
+        StorageStrategy storageStrategy = new StorageStrategy(
+            this.client,
+            builder.tableName,
+            builder.s3Client,
+            builder.s3Bucket,
+            builder.s3KeyPrefix,
+            builder.ttlSeconds
+        );
+
         this.repository = new DynamoDBRepository(
             this.client,
             builder.tableName,
-            builder.ttlSeconds
+            builder.ttlSeconds,
+            storageStrategy
         );
 
         // Table initialization
@@ -307,7 +393,9 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
                                       LinkedList<Checkpoint> checkpoints,
                                       Checkpoint checkpoint) throws Exception {
         final String threadId = threadId(config);
-        log.debug("Inserting checkpoint '{}' for thread '{}'", checkpoint.getId(), threadId);
+        final String parentCheckpointId = config.checkPointId().orElse(null);
+        log.debug("Inserting checkpoint '{}' for thread '{}' (parent='{}')",
+                checkpoint.getId(), threadId, parentCheckpointId);
 
         final byte[] payload = encodeState(checkpoint.getState());
         repository.putCheckpoint(
@@ -316,7 +404,9 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
             checkpoint.getNodeId(),
             checkpoint.getNextNodeId(),
             payload,
-            stateSerializer.contentType()
+            stateSerializer.contentType(),
+            parentCheckpointId,
+            false  // insert-only: conditional write
         );
     }
 
@@ -332,7 +422,9 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
             repository.deleteCheckpoint(threadId, oldId);
         });
 
-        log.debug("Updating checkpoint '{}' for thread '{}'", checkpoint.getId(), threadId);
+        final String parentCheckpointId = config.checkPointId().orElse(null);
+        log.debug("Updating checkpoint '{}' for thread '{}' (parent='{}')",
+                checkpoint.getId(), threadId, parentCheckpointId);
         final byte[] payload = encodeState(checkpoint.getState());
         repository.putCheckpoint(
             threadId,
@@ -340,7 +432,9 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
             checkpoint.getNodeId(),
             checkpoint.getNextNodeId(),
             payload,
-            stateSerializer.contentType()
+            stateSerializer.contentType(),
+            parentCheckpointId,
+            true  // update path: allow overwrite
         );
     }
 
@@ -350,6 +444,23 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
         log.debug("Releasing thread '{}'", threadId);
         repository.markThreadReleased(threadId);
         return new Tag(threadId, checkpoints);
+    }
+
+    /**
+     * Deletes all checkpoints and associated data for the given thread.
+     *
+     * <p>This is a <em>hard delete</em> that permanently removes all checkpoint
+     * metadata items, payload chunk items, and the released sentinel (if present)
+     * from DynamoDB. The operation is idempotent: calling it on a non-existent
+     * or already-deleted thread is a no-op.
+     *
+     * <p>Note: this method is specific to {@link DynamoDBSaver} and is not part
+     * of the {@link BaseCheckpointSaver} contract.
+     *
+     * @param threadId the thread identifier whose data should be deleted
+     */
+    public void deleteThread(String threadId) {
+        repository.deleteThread(threadId);
     }
 
     /**

--- a/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaver.java
+++ b/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaver.java
@@ -6,21 +6,10 @@ import org.bsc.langgraph4j.serializer.PlainTextStateSerializer;
 import org.bsc.langgraph4j.state.AgentState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
-import software.amazon.awssdk.core.retry.RetryMode;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
@@ -46,9 +35,13 @@ import static java.util.Objects.requireNonNull;
  *
  * <h2>Usage</h2>
  * <pre>{@code
+ * DynamoDbClient client = DynamoDbClient.builder()
+ *     .region(Region.US_EAST_1)
+ *     .build();
+ * 
  * DynamoDBSaver saver = DynamoDBSaver.builder()
  *     .tableName("lg4j-checkpoints")
- *     .region("us-east-1")
+ *     .dynamoDbClient(client)
  *     .stateSerializer(new ObjectStreamStateSerializer<>(AgentState::new))
  *     .createTableIfNotExists(true)
  *     .build();
@@ -56,10 +49,14 @@ import static java.util.Objects.requireNonNull;
  *
  * <p>For local development / testing, point to a local DynamoDB endpoint:
  * <pre>{@code
+ * DynamoDbClient localClient = DynamoDbClient.builder()
+ *     .endpointOverride(URI.create("http://localhost:8000"))
+ *     .region(Region.US_EAST_1)
+ *     .build();
+ *
  * DynamoDBSaver saver = DynamoDBSaver.builder()
  *     .tableName("lg4j-checkpoints")
- *     .endpointUrl("http://localhost:8000")
- *     .region("us-east-1")
+ *     .dynamoDbClient(localClient)
  *     .stateSerializer(serializer)
  *     .createTableIfNotExists(true)
  *     .dropTableFirst(true)
@@ -78,20 +75,16 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
     public static class Builder {
 
         private String tableName;
-        private String region;
-        private String endpointUrl;
-        private AwsCredentialsProvider credentialsProvider;
         private StateSerializer<? extends AgentState> stateSerializer;
         private boolean plainTextStateSerializerLegacyMode = false;
         private Long ttlSeconds;
         private boolean createTableIfNotExists = false;
         private boolean dropTableFirst = false;
-        /** Inject a fully configured client (useful for tests or shared clients). */
+        /** Inject a fully configured client (required). */
         private DynamoDbClient dynamoDbClient;
         private String s3Bucket;
         private String s3KeyPrefix;
-        private String s3EndpointUrl;
-        /** Inject a pre-configured S3 client. */
+        /** Inject a pre-configured S3 client (required if s3Bucket is set). */
         private S3Client s3Client;
 
         Builder() {}
@@ -99,27 +92,6 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
         /** Name of the DynamoDB table. Required. */
         public Builder tableName(String tableName) {
             this.tableName = tableName;
-            return this;
-        }
-
-        /** AWS region (e.g. {@code "us-east-1"}). Ignored when a custom client is provided. */
-        public Builder region(String region) {
-            this.region = region;
-            return this;
-        }
-
-        /**
-         * Override the DynamoDB service endpoint URL.
-         * Useful for local DynamoDB ({@code "http://localhost:8000"}) and LocalStack.
-         */
-        public Builder endpointUrl(String endpointUrl) {
-            this.endpointUrl = endpointUrl;
-            return this;
-        }
-
-        /** Custom AWS credentials provider. Defaults to {@link DefaultCredentialsProvider}. */
-        public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
-            this.credentialsProvider = credentialsProvider;
             return this;
         }
 
@@ -173,9 +145,7 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
         }
 
         /**
-         * Inject a pre-configured {@link DynamoDbClient}. When provided, the
-         * {@link #region}, {@link #endpointUrl}, and {@link #credentialsProvider}
-         * settings are ignored.
+         * Inject a fully configured {@link DynamoDbClient}. Required.
          */
         public Builder dynamoDbClient(DynamoDbClient client) {
             this.dynamoDbClient = client;
@@ -183,8 +153,8 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
         }
 
         /**
-         * S3 bucket name for large-payload offloading. When set (along with
-         * {@link #region}), payloads exceeding 350KB are automatically stored
+         * S3 bucket name for large-payload offloading. When set,
+         * payloads exceeding 350KB are automatically stored
          * in S3 instead of DynamoDB.
          */
         public Builder s3Bucket(String s3Bucket) {
@@ -202,16 +172,7 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
         }
 
         /**
-         * Override the S3 service endpoint URL. Useful for MinIO or LocalStack.
-         */
-        public Builder s3EndpointUrl(String s3EndpointUrl) {
-            this.s3EndpointUrl = s3EndpointUrl;
-            return this;
-        }
-
-        /**
-         * Inject a pre-configured {@link S3Client}. When provided, the S3 client
-         * is not built internally.
+         * Inject a pre-configured {@link S3Client}. Required if an s3Bucket is configured.
          */
         public Builder s3Client(S3Client s3Client) {
             this.s3Client = s3Client;
@@ -222,47 +183,10 @@ public class DynamoDBSaver extends AbstractCheckpointSaver {
         public DynamoDBSaver build() {
             requireNonNull(tableName, "'tableName' must not be null");
             requireNonNull(stateSerializer, "'stateSerializer' must not be null");
+            requireNonNull(dynamoDbClient, "'dynamoDbClient' must not be null");
 
-            if (dynamoDbClient == null) {
-                DynamoDbClientBuilder builder = DynamoDbClient.builder();
-
-                if (region != null) {
-                    builder.region(Region.of(region));
-                }
-                if (endpointUrl != null) {
-                    builder.endpointOverride(URI.create(endpointUrl));
-                }
-                builder.credentialsProvider(
-                    credentialsProvider != null ? credentialsProvider : DefaultCredentialsProvider.create()
-                );
-
-                // User-agent + adaptive retry for observability and resilience
-                ClientOverrideConfiguration overrideConfig = ClientOverrideConfiguration.builder()
-                    .putAdvancedOption(
-                        SdkAdvancedClientOption.USER_AGENT_SUFFIX,
-                        "x-client-framework:langgraph4j-dynamodb")
-                    .retryStrategy(RetryMode.ADAPTIVE)
-                    .build();
-                builder.overrideConfiguration(overrideConfig);
-
-                dynamoDbClient = builder.build();
-            }
-
-            // Build S3 client if bucket is configured
-            if (s3Client == null && s3Bucket != null) {
-                S3ClientBuilder s3Builder = S3Client.builder()
-                    .forcePathStyle(true);
-
-                if (region != null) {
-                    s3Builder.region(Region.of(region));
-                }
-                if (s3EndpointUrl != null) {
-                    s3Builder.endpointOverride(URI.create(s3EndpointUrl));
-                }
-                s3Builder.credentialsProvider(
-                    credentialsProvider != null ? credentialsProvider : DefaultCredentialsProvider.create()
-                );
-                s3Client = s3Builder.build();
+            if (s3Bucket != null) {
+                requireNonNull(s3Client, "'s3Client' must not be null when 's3Bucket' is configured");
             }
 
             // dropTableFirst implies createTableIfNotExists

--- a/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/StorageStrategy.java
+++ b/langgraph4j-dynamodb-saver/src/main/java/org/bsc/langgraph4j/checkpoint/StorageStrategy.java
@@ -1,0 +1,549 @@
+package org.bsc.langgraph4j.checkpoint;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.BucketLifecycleConfiguration;
+import software.amazon.awssdk.services.s3.model.LifecycleExpiration;
+import software.amazon.awssdk.services.s3.model.LifecycleRule;
+import software.amazon.awssdk.services.s3.model.LifecycleRuleFilter;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.Tag;
+import software.amazon.awssdk.services.s3.model.Tagging;
+
+/**
+ * Determines and executes storage strategy (DynamoDB vs S3) based on data size.
+ *
+ * <p>The 350KB threshold provides a safety margin below DynamoDB's 400KB item
+ * size limit. When S3 is configured and the payload exceeds the threshold, data
+ * is automatically offloaded to S3. Otherwise it stays in the DynamoDB chunk
+ * table.
+ *
+ * <p>This class closely follows the Python reference implementation at
+ * {@code langchain-aws/checkpoint/dynamodb/storage_strategy.py}.
+ */
+class StorageStrategy {
+
+    private static final Logger log = LoggerFactory.getLogger(StorageStrategy.class);
+
+    /** Payloads larger than 350KB are offloaded to S3 (50KB safety margin). */
+    static final int S3_OFFLOAD_THRESHOLD = 350 * 1024;
+
+    /** Maximum number of items per DynamoDB {@code batchWriteItem} request. */
+    private static final int BATCH_WRITE_MAX_ITEMS = 25;
+
+    /** Maximum number of objects per S3 {@code deleteObjects} request. */
+    private static final int S3_DELETE_MAX_OBJECTS = 1000;
+
+    /** Maximum retry rounds for unprocessed DynamoDB batch items. */
+    private static final int BATCH_RETRY_MAX_ROUNDS = 3;
+
+    /** Backoff delay in milliseconds between batch retry rounds. */
+    private static final long BATCH_RETRY_BACKOFF_MS = 100;
+
+    private final DynamoDbClient dynamoDbClient;
+    private final String tableName;
+    private final S3Client s3Client;
+    private final String s3Bucket;
+    private final String s3KeyPrefix;
+    private final Long ttlSeconds;
+    private final boolean s3Enabled;
+
+    /**
+     * Creates a new storage strategy.
+     *
+     * @param dynamoDbClient DynamoDB client for chunk table operations
+     * @param tableName name of the DynamoDB table for payload chunks
+     * @param s3Client optional S3 client for large data offloading (nullable)
+     * @param s3Bucket optional S3 bucket name (nullable)
+     * @param s3KeyPrefix optional prefix prepended to all S3 keys (nullable)
+     * @param ttlSeconds optional TTL in seconds for automatic cleanup (nullable)
+     */
+    StorageStrategy(DynamoDbClient dynamoDbClient,
+                    String tableName,
+                    S3Client s3Client,
+                    String s3Bucket,
+                    String s3KeyPrefix,
+                    Long ttlSeconds) {
+        this.dynamoDbClient = dynamoDbClient;
+        this.tableName = tableName;
+        this.s3Client = s3Client;
+        this.s3Bucket = s3Bucket;
+        this.s3KeyPrefix = s3KeyPrefix != null ? s3KeyPrefix.replaceAll("^/+|/+$", "") : null;
+        this.ttlSeconds = ttlSeconds;
+        this.s3Enabled = s3Client != null && s3Bucket != null;
+
+        // Configure S3 lifecycle policy if TTL is set
+        if (this.s3Enabled && this.ttlSeconds != null && this.ttlSeconds > 0) {
+            ensureS3LifecyclePolicy();
+        }
+    }
+
+    // ─── Threshold logic ────────────────────────────────────────────────────────
+
+    /**
+     * Returns {@code true} if the data should be offloaded to S3.
+     *
+     * @param data serialized payload bytes
+     * @return true if data exceeds threshold and S3 is configured
+     */
+    boolean shouldOffloadToS3(byte[] data) {
+        if (!s3Enabled) {
+            return false;
+        }
+        if (data.length > S3_OFFLOAD_THRESHOLD) {
+            log.debug("Data size {}KB exceeds threshold {}KB - will offload to S3",
+                    data.length / 1024, S3_OFFLOAD_THRESHOLD / 1024);
+            return true;
+        }
+        log.debug("Data size {}KB below threshold {}KB - will store in DynamoDB",
+                data.length / 1024, S3_OFFLOAD_THRESHOLD / 1024);
+        return false;
+    }
+
+    // ─── Store operations ───────────────────────────────────────────────────────
+
+    /**
+     * Stores data using the appropriate backend based on size.
+     *
+     * @param chunkKey PK for DynamoDB chunk table
+     * @param s3Key S3 key to use if offloading to S3
+     * @param data serialized payload bytes
+     * @param allowOverwrite if false, insert-only (skip if exists)
+     * @return storage location: {@code "DYNAMODB"} or {@code "S3"}
+     */
+    String storeData(String chunkKey, String s3Key, byte[] data, boolean allowOverwrite) {
+        if (shouldOffloadToS3(data)) {
+            storeToS3(s3Key, data, allowOverwrite);
+            log.debug("Stored {}KB to S3: {}", data.length / 1024, s3Key);
+            return "S3";
+        }
+
+        storeToDynamoDB(chunkKey, data, allowOverwrite);
+        log.debug("Stored {}KB to DynamoDB chunk table: {}", data.length / 1024, chunkKey);
+        return "DYNAMODB";
+    }
+
+    // ─── Retrieve operations ────────────────────────────────────────────────────
+
+    /**
+     * Retrieves data from the appropriate storage backend.
+     *
+     * @param refKey reference key (chunk table PK or S3 key)
+     * @param refLocation storage location ({@code "DYNAMODB"} or {@code "S3"})
+     * @return the raw bytes, or {@code null} if not found
+     */
+    byte[] retrieveData(String refKey, String refLocation) {
+        if ("DYNAMODB".equals(refLocation)) {
+            return retrieveFromDynamoDB(refKey);
+        }
+        if ("S3".equals(refLocation)) {
+            return retrieveFromS3(refKey);
+        }
+        log.error("Invalid storage location: {}", refLocation);
+        return null;
+    }
+
+    // ─── Batch delete operations ────────────────────────────────────────────────
+
+    /**
+     * Deletes multiple data items using batch operations, grouped by location.
+     *
+     * @param items list of (refKey, refLocation) pairs to delete
+     * @return map with "failed" key containing list of failed ref keys
+     */
+    Map<String, List<String>> batchDeleteData(List<String[]> items) {
+        if (items.isEmpty()) {
+            return Map.of("failed", List.of());
+        }
+
+        // Group items by storage location
+        List<String> dynamoDbKeys = new ArrayList<>();
+        List<String> s3Keys = new ArrayList<>();
+
+        for (String[] item : items) {
+            String refKey = item[0];
+            String refLocation = item[1];
+            if ("DYNAMODB".equals(refLocation)) {
+                dynamoDbKeys.add(refKey);
+            } else if ("S3".equals(refLocation)) {
+                s3Keys.add(refKey);
+            } else {
+                log.warn("Invalid storage location: {}", refLocation);
+            }
+        }
+
+        List<String> failedKeys = new ArrayList<>();
+
+        // Batch delete from DynamoDB
+        if (!dynamoDbKeys.isEmpty()) {
+            failedKeys.addAll(batchDeleteFromDynamoDB(dynamoDbKeys));
+        }
+
+        // Batch delete from S3
+        if (!s3Keys.isEmpty()) {
+            failedKeys.addAll(batchDeleteFromS3(s3Keys));
+        }
+
+        if (!failedKeys.isEmpty()) {
+            log.warn("Failed to delete {} item(s): {}", failedKeys.size(), failedKeys);
+        }
+
+        return Map.of("failed", failedKeys);
+    }
+
+    // ─── DynamoDB storage operations ────────────────────────────────────────────
+
+    private void storeToDynamoDB(String chunkKey, byte[] data, boolean allowOverwrite) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("PK", s(chunkKey));
+        item.put("SK", s("CHUNK"));
+        item.put("payload", b(data));
+
+        if (ttlSeconds != null && ttlSeconds > 0) {
+            item.put("ttl", n(Instant.now().getEpochSecond() + ttlSeconds));
+        }
+
+        PutItemRequest.Builder reqBuilder = PutItemRequest.builder()
+                .tableName(tableName)
+                .item(item);
+
+        if (!allowOverwrite) {
+            reqBuilder.conditionExpression("attribute_not_exists(PK)");
+        }
+
+        try {
+            dynamoDbClient.putItem(reqBuilder.build());
+        } catch (ConditionalCheckFailedException e) {
+            if (!allowOverwrite) {
+                log.debug("Chunk already exists, skipping: PK={}", chunkKey);
+                return;
+            }
+            throw e;
+        }
+    }
+
+    private byte[] retrieveFromDynamoDB(String chunkKey) {
+        GetItemResponse response = dynamoDbClient.getItem(r -> r
+                .tableName(tableName)
+                .key(Map.of(
+                        "PK", s(chunkKey),
+                        "SK", s("CHUNK")
+                ))
+                .projectionExpression("payload")
+        );
+
+        if (!response.hasItem() || !response.item().containsKey("payload")) {
+            log.debug("Item not found in chunk table: PK={}", chunkKey);
+            return null;
+        }
+
+        return response.item().get("payload").b().asByteArray();
+    }
+
+    private List<String> batchDeleteFromDynamoDB(List<String> chunkKeys) {
+        if (chunkKeys == null || chunkKeys.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<String> failedKeys = new ArrayList<>();
+
+        for (int i = 0; i < chunkKeys.size(); i += BATCH_WRITE_MAX_ITEMS) {
+            int end = Math.min(i + BATCH_WRITE_MAX_ITEMS, chunkKeys.size());
+            List<String> batch = chunkKeys.subList(i, end);
+
+            List<WriteRequest> deleteRequests = batch.stream()
+                    .map(key -> WriteRequest.builder()
+                            .deleteRequest(DeleteRequest.builder()
+                                    .key(Map.of("PK", s(key), "SK", s("CHUNK")))
+                                    .build())
+                            .build())
+                    .toList();
+
+            Map<String, List<WriteRequest>> requestItems = Map.of(tableName, deleteRequests);
+
+            boolean success = processBatchWithRetry(requestItems);
+            if (!success) {
+                failedKeys.addAll(batch);
+            }
+        }
+
+        return failedKeys;
+    }
+
+    private boolean processBatchWithRetry(Map<String, List<WriteRequest>> initialRequestItems) {
+        Map<String, List<WriteRequest>> requestItems = initialRequestItems;
+        int retryRound = 0;
+
+        try {
+            while (!requestItems.isEmpty() && retryRound <= BATCH_RETRY_MAX_ROUNDS) {
+                BatchWriteItemRequest request = BatchWriteItemRequest.builder()
+                        .requestItems(requestItems)
+                        .build();
+
+                BatchWriteItemResponse response = dynamoDbClient.batchWriteItem(request);
+
+                if (!response.hasUnprocessedItems() || response.unprocessedItems().isEmpty()) {
+                    return true;
+                }
+
+                requestItems = response.unprocessedItems();
+                retryRound++;
+
+                if (retryRound <= BATCH_RETRY_MAX_ROUNDS) {
+                    sleepForBackoff(retryRound);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error during DynamoDB batch delete", e);
+            return false;
+        }
+
+        return requestItems.isEmpty();
+    }
+
+    private void sleepForBackoff(int retryRound) {
+        try {
+            long backoffMs = BATCH_RETRY_BACKOFF_MS * (1L << (retryRound - 1));
+            Thread.sleep(backoffMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted during batch delete backoff", e);
+        }
+    }
+
+    // ─── S3 storage operations ──────────────────────────────────────────────────
+
+    private String prefixedS3Key(String s3Key) {
+        if (s3KeyPrefix != null) {
+            return s3KeyPrefix + "/" + s3Key;
+        }
+        return s3Key;
+    }
+
+    private void storeToS3(String s3Key, byte[] data, boolean allowOverwrite) {
+        if (!s3Enabled) {
+            String msg = "S3 is not configured but offloading was attempted";
+            throw new IllegalStateException(msg);
+        }
+
+        String prefixedKey = prefixedS3Key(s3Key);
+
+        PutObjectRequest.Builder reqBuilder = PutObjectRequest.builder()
+                .bucket(s3Bucket)
+                .key(prefixedKey);
+
+        // Conditional write: only put if object doesn't exist
+        if (!allowOverwrite) {
+            reqBuilder.ifNoneMatch("*");
+        }
+
+        // Add TTL tag for lifecycle policy expiration
+        if (ttlSeconds != null && ttlSeconds > 0) {
+            int expirationDays = Math.max(1, (int) Math.ceil((double) ttlSeconds / 86400));
+            reqBuilder.tagging(Tagging.builder()
+                    .tagSet(Tag.builder()
+                            .key("ttl-days")
+                            .value(String.valueOf(expirationDays))
+                            .build())
+                    .build());
+        }
+
+        try {
+            s3Client.putObject(reqBuilder.build(), RequestBody.fromBytes(data));
+            log.debug("Stored to S3: bucket={}, key={}, size={}B", s3Bucket, prefixedKey, data.length);
+        } catch (S3Exception e) {
+            // PreconditionFailed means object already exists (conditional write)
+            if ("PreconditionFailed".equals(e.awsErrorDetails().errorCode()) && !allowOverwrite) {
+                log.debug("S3 object already exists, skipping: key={}", prefixedKey);
+                return;
+            }
+            throw e;
+        }
+    }
+
+    private byte[] retrieveFromS3(String s3Key) {
+        if (!s3Enabled) {
+            log.error("S3 is not configured but retrieval was attempted");
+            return null;
+        }
+
+        String prefixedKey = prefixedS3Key(s3Key);
+
+        try {
+            var response = s3Client.getObject(GetObjectRequest.builder()
+                    .bucket(s3Bucket)
+                    .key(prefixedKey)
+                    .build());
+            return response.readAllBytes();
+        } catch (NoSuchKeyException e) {
+            log.debug("S3 object not found: bucket={}, key={}", s3Bucket, prefixedKey);
+            return null;
+        } catch (IOException e) {
+            String msg = "Failed to read S3 object: " + prefixedKey;
+            throw new RuntimeException(msg, e);
+        }
+    }
+
+    private List<String> batchDeleteFromS3(List<String> s3Keys) {
+        if (!s3Enabled) {
+            log.warn("S3 is not configured but batch delete was attempted");
+            return new ArrayList<>(s3Keys);
+        }
+
+        if (s3Keys == null || s3Keys.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<String> failedKeys = new ArrayList<>();
+
+        for (int i = 0; i < s3Keys.size(); i += S3_DELETE_MAX_OBJECTS) {
+            int end = Math.min(i + S3_DELETE_MAX_OBJECTS, s3Keys.size());
+            List<String> batch = s3Keys.subList(i, end);
+
+            List<ObjectIdentifier> objects = batch.stream()
+                    .map(key -> ObjectIdentifier.builder().key(prefixedS3Key(key)).build())
+                    .toList();
+
+            try {
+                DeleteObjectsResponse response = s3Client.deleteObjects(DeleteObjectsRequest.builder()
+                        .bucket(s3Bucket)
+                        .delete(Delete.builder().objects(objects).build())
+                        .build());
+
+                if (response.hasErrors()) {
+                    for (var error : response.errors()) {
+                        failedKeys.add(error.key());
+                        log.warn("Failed to delete S3 object: key={}, code={}", error.key(), error.code());
+                    }
+                }
+            } catch (S3Exception e) {
+                log.error("Error during S3 batch delete", e);
+                failedKeys.addAll(batch);
+            }
+        }
+
+        return failedKeys;
+    }
+
+    // ─── S3 Lifecycle Policy ────────────────────────────────────────────────────
+
+    /**
+     * Configures an S3 lifecycle rule for TTL-based expiration if one does not
+     * already exist.
+     */
+    private void ensureS3LifecyclePolicy() {
+        if (!s3Enabled || ttlSeconds == null || ttlSeconds <= 0 || s3Client == null) {
+            return;
+        }
+
+        try {
+            int expirationDays = Math.max(1, (int) Math.ceil((double) ttlSeconds / 86400));
+            String idPrefix = s3KeyPrefix != null ? s3KeyPrefix.replace("/", "-") : "root";
+            String ruleId = idPrefix + "-ttl-expiration-" + expirationDays + "d";
+
+            // Check existing rules
+            List<LifecycleRule> existingRules;
+            try {
+                var response = s3Client.getBucketLifecycleConfiguration(r -> r.bucket(s3Bucket));
+                existingRules = new ArrayList<>(response.rules());
+
+                // Skip if rule already exists
+                if (existingRules.stream().anyMatch(r -> ruleId.equals(r.id()))) {
+                    log.debug("S3 lifecycle rule '{}' exists in {}", ruleId, s3Bucket);
+                    return;
+                }
+            } catch (S3Exception e) {
+                if ("NoSuchLifecycleConfiguration".equals(e.awsErrorDetails().errorCode())) {
+                    existingRules = new ArrayList<>();
+                } else {
+                    throw e;
+                }
+            }
+
+            // Build lifecycle filter
+            LifecycleRuleFilter filter;
+            if (s3KeyPrefix != null) {
+                filter = LifecycleRuleFilter.builder()
+                        .and(a -> a
+                                .prefix(s3KeyPrefix + "/")
+                                .tags(Tag.builder()
+                                        .key("ttl-days")
+                                        .value(String.valueOf(expirationDays))
+                                        .build()))
+                        .build();
+            } else {
+                filter = LifecycleRuleFilter.builder()
+                        .tag(Tag.builder()
+                                .key("ttl-days")
+                                .value(String.valueOf(expirationDays))
+                                .build())
+                        .build();
+            }
+
+            // Add new rule
+            existingRules.add(LifecycleRule.builder()
+                    .id(ruleId)
+                    .status("Enabled")
+                    .filter(filter)
+                    .expiration(LifecycleExpiration.builder()
+                            .days(expirationDays)
+                            .build())
+                    .build());
+
+            final List<LifecycleRule> finalRules = existingRules;
+            s3Client.putBucketLifecycleConfiguration(r -> r
+                    .bucket(s3Bucket)
+                    .lifecycleConfiguration(BucketLifecycleConfiguration.builder()
+                            .rules(finalRules)
+                            .build()));
+
+            log.info("Added S3 lifecycle rule '{}' to {}: expire after {} days",
+                    ruleId, s3Bucket, expirationDays);
+
+        } catch (S3Exception e) {
+            log.warn("Failed to configure S3 lifecycle: {}",
+                    e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : e.getMessage());
+        }
+    }
+
+    // ─── AttributeValue helpers ─────────────────────────────────────────────────
+
+    private static AttributeValue s(String value) {
+        return AttributeValue.builder().s(value).build();
+    }
+
+    private static AttributeValue n(long value) {
+        return AttributeValue.builder().n(String.valueOf(value)).build();
+    }
+
+    private static AttributeValue b(byte[] value) {
+        return AttributeValue.builder().b(SdkBytes.fromByteArray(value)).build();
+    }
+}

--- a/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/DynamoDBRepositoryTest.java
+++ b/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/DynamoDBRepositoryTest.java
@@ -1,0 +1,74 @@
+package org.bsc.langgraph4j.checkpoint;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link DynamoDBRepository} key generation functions.
+ *
+ * <p>These tests verify the single-table design key patterns without requiring
+ * a DynamoDB instance.
+ */
+class DynamoDBRepositoryTest {
+
+    @Test
+    void testCheckpointPK() {
+        assertEquals("CHECKPOINT_t1", DynamoDBRepository.checkpointPK("t1"));
+        assertEquals("CHECKPOINT_thread-abc-123", DynamoDBRepository.checkpointPK("thread-abc-123"));
+    }
+
+    @Test
+    void testCheckpointSK() {
+        assertEquals("cp-001", DynamoDBRepository.checkpointSK("cp-001"));
+    }
+
+    @Test
+    void testChunkPK() {
+        assertEquals("CHUNK_t1#cp1", DynamoDBRepository.chunkPK("t1", "cp1"));
+        assertEquals("CHUNK_thread-abc#checkpoint-xyz",
+                DynamoDBRepository.chunkPK("thread-abc", "checkpoint-xyz"));
+    }
+
+    @Test
+    void testChunkSK() {
+        assertEquals("CHUNK", DynamoDBRepository.chunkSK());
+    }
+
+    @Test
+    void testReleasedPK() {
+        assertEquals("RELEASED_t1", DynamoDBRepository.releasedPK("t1"));
+    }
+
+    @Test
+    void testReleasedSK() {
+        assertEquals("MARKER", DynamoDBRepository.releasedSK());
+    }
+
+    @Test
+    void testCheckpointRecordWithParentAndRefFields() {
+        var record = new DynamoDBRepository.CheckpointRecord(
+                "thread-1", "cp-123", "node_a", "node_b",
+                new byte[]{1, 2, 3}, "application/octet-stream", 1000L,
+                "cp-parent", "DYNAMODB", "CHUNK_thread-1#cp-123"
+        );
+
+        assertEquals("thread-1", record.threadId());
+        assertEquals("cp-123", record.checkpointId());
+        assertEquals("cp-parent", record.parentCheckpointId());
+        assertEquals("DYNAMODB", record.refLoc());
+        assertEquals("CHUNK_thread-1#cp-123", record.refKey());
+    }
+
+    @Test
+    void testCheckpointRecordNullableParent() {
+        var record = new DynamoDBRepository.CheckpointRecord(
+                "thread-1", "cp-001", "start", "__end__",
+                new byte[0], "text/plain", 500L,
+                null, "DYNAMODB", "CHUNK_thread-1#cp-001"
+        );
+
+        assertNull(record.parentCheckpointId());
+        assertEquals("DYNAMODB", record.refLoc());
+    }
+}

--- a/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaverTest.java
+++ b/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaverTest.java
@@ -392,4 +392,233 @@ public class DynamoDBSaverTest {
         // Caller is responsible for closing the externally managed client
         externalClient.close();
     }
+
+    // ─── Phase 1.5 Tests ─────────────────────────────────────────────────────
+
+    /**
+     * Verify that {@code deleteThread()} removes all checkpoint metadata,
+     * payload chunks, and the released marker from DynamoDB.
+     */
+    @ParameterizedTest
+    @EnumSource(StateSerializerEnum.class)
+    void testDeleteThread(StateSerializerEnum param) throws Exception {
+        var saver = buildSaver(param);
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(false)
+            .build();
+
+        var threadId = "thread-delete-test";
+        var runnableConfig = RunnableConfig.builder().threadId(threadId).build();
+        var workflow = singleNodeGraph().compile(compileConfig);
+
+        // Run the graph to create checkpoints
+        workflow.invoke(Map.of("input", "test-delete"), runnableConfig);
+
+        // Verify checkpoints exist
+        var history = workflow.getStateHistory(runnableConfig);
+        assertFalse(history.isEmpty(), "Checkpoints should exist before delete");
+
+        // Delete the thread
+        saver.deleteThread(threadId);
+
+        // Verify all checkpoints are gone
+        var historyAfter = workflow.getStateHistory(runnableConfig);
+        assertTrue(historyAfter.isEmpty(), "All checkpoints must be removed after deleteThread");
+
+        // Verify via raw DynamoDB scan that no items remain for this thread
+        var scanResponse = saver.getDynamoDbClient().scan(r -> r
+                .tableName(TABLE_NAME)
+                .filterExpression("contains(PK, :tid)")
+                .expressionAttributeValues(Map.of(
+                        ":tid", software.amazon.awssdk.services.dynamodb.model.AttributeValue.builder()
+                                .s(threadId).build()
+                ))
+        );
+        assertEquals(0, scanResponse.count(),
+                "No DynamoDB items should remain for the deleted thread");
+    }
+
+    /**
+     * Verify that calling {@code deleteThread()} on a non-existent thread
+     * is a no-op (idempotent).
+     */
+    @Test
+    void testDeleteThreadIdempotent() throws Exception {
+        var saver = buildSaver(StateSerializerEnum.BINARY);
+
+        // Should not throw
+        assertDoesNotThrow(() -> saver.deleteThread("non-existent-thread-id"));
+    }
+
+    /**
+     * Verify that checkpoint metadata items carry the correct
+     * {@code ref_loc} and {@code ref_key} attributes.
+     */
+    @ParameterizedTest
+    @EnumSource(StateSerializerEnum.class)
+    void testRefLocRefKeyAttributes(StateSerializerEnum param) throws Exception {
+        var saver = buildSaver(param);
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(false)
+            .build();
+
+        var threadId = "thread-refkey-test";
+        var runnableConfig = RunnableConfig.builder().threadId(threadId).build();
+        var workflow = singleNodeGraph().compile(compileConfig);
+
+        workflow.invoke(Map.of("input", "refkey-test"), runnableConfig);
+
+        // Query checkpoint metadata items directly
+        var queryResponse = saver.getDynamoDbClient().query(r -> r
+                .tableName(TABLE_NAME)
+                .keyConditionExpression("PK = :pk")
+                .expressionAttributeValues(Map.of(
+                        ":pk", software.amazon.awssdk.services.dynamodb.model.AttributeValue.builder()
+                                .s("CHECKPOINT_" + threadId).build()
+                ))
+        );
+
+        assertFalse(queryResponse.items().isEmpty(), "Should have checkpoint metadata items");
+
+        for (var item : queryResponse.items()) {
+            // Verify ref_loc is present and set to DYNAMODB
+            assertTrue(item.containsKey("ref_loc"), "Item should have ref_loc attribute");
+            assertEquals("DYNAMODB", item.get("ref_loc").s());
+
+            // Verify ref_key is present and follows CHUNK_{threadId}#{checkpointId} pattern
+            assertTrue(item.containsKey("ref_key"), "Item should have ref_key attribute");
+            String refKey = item.get("ref_key").s();
+            assertTrue(refKey.startsWith("CHUNK_" + threadId + "#"),
+                    "ref_key should follow CHUNK_{threadId}#{checkpointId} pattern, got: " + refKey);
+        }
+
+        saver.deleteThread(threadId);
+    }
+
+    /**
+     * Verify that the {@code parentCheckpointId} attribute tracks lineage
+     * correctly across multiple graph executions.
+     */
+    @org.junit.jupiter.api.Disabled("Pending upstream langgraph4j-core support for checkpoint lineage")
+    @ParameterizedTest
+    @EnumSource(StateSerializerEnum.class)
+    void testParentCheckpointIdLineage(StateSerializerEnum param) throws Exception {
+        var saver = buildSaver(param);
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(false)
+            .build();
+
+        var threadId = "thread-lineage-test";
+        var runnableConfig = RunnableConfig.builder().threadId(threadId).build();
+        var workflow = chatGraph().compile(compileConfig);
+
+        // Run two turns to create a chain of checkpoints
+        workflow.invoke(Map.of("user_input", "Hi"), runnableConfig);
+        workflow.invoke(Map.of("user_input", "weather"), runnableConfig);
+
+        // Query all checkpoint metadata items, sorted by savedAt
+        var queryResponse = saver.getDynamoDbClient().query(r -> r
+                .tableName(TABLE_NAME)
+                .keyConditionExpression("PK = :pk")
+                .expressionAttributeValues(Map.of(
+                        ":pk", software.amazon.awssdk.services.dynamodb.model.AttributeValue.builder()
+                                .s("CHECKPOINT_" + threadId).build()
+                ))
+        );
+
+        var items = new ArrayList<>(queryResponse.items());
+        assertTrue(items.size() >= 2, "Should have at least 2 checkpoints from 2 turns");
+
+        // Sort by savedAt to establish chronological order
+        items.sort((a, b) -> {
+            long aTime = Long.parseLong(a.get("savedAt").n());
+            long bTime = Long.parseLong(b.get("savedAt").n());
+            return Long.compare(aTime, bTime);
+        });
+
+        // First checkpoint should have no parent
+        var firstItem = items.get(0);
+        assertFalse(firstItem.containsKey("parentCheckpointId"),
+                "First checkpoint should not have a parentCheckpointId");
+
+        // Subsequent checkpoints should have a parentCheckpointId
+        boolean foundParent = false;
+        for (int i = 1; i < items.size(); i++) {
+            if (items.get(i).containsKey("parentCheckpointId")) {
+                foundParent = true;
+                String parentId = items.get(i).get("parentCheckpointId").s();
+                assertNotNull(parentId, "parentCheckpointId should not be null");
+                assertFalse(parentId.isEmpty(), "parentCheckpointId should not be empty");
+            }
+        }
+        assertTrue(foundParent, "At least one non-first checkpoint should have a parentCheckpointId");
+
+        saver.deleteThread(threadId);
+    }
+
+    /**
+     * Verify that conditional writes prevent silent overwrites during inserts,
+     * but allow updates when explicitly requested.
+     */
+    @ParameterizedTest
+    @EnumSource(StateSerializerEnum.class)
+    void testConditionalWrites(StateSerializerEnum param) throws Exception {
+        var saver = buildSaver(param);
+        var threadId = "thread-conditional-write";
+        var config = RunnableConfig.builder().threadId(threadId).build();
+
+        var state1 = Map.<String, Object>of("key", "value1");
+        var state2 = Map.<String, Object>of("key", "value2");
+
+        var checkpoint = Checkpoint.builder()
+            .id("fixed-checkpoint-id")
+            .nodeId("node1")
+            .nextNodeId("node2")
+            .state(state1)
+            .build();
+
+        // 1. Insert checkpoint (routes to insertedCheckpoint, allowOverwrite=false)
+        saver.put(config, checkpoint);
+
+        var getConfig = RunnableConfig.builder()
+                .threadId(threadId)
+                .checkPointId("fixed-checkpoint-id")
+                .build();
+
+        // Verify state is value1
+        var loaded = saver.get(getConfig);
+        assertTrue(loaded.isPresent());
+        assertEquals("value1", loaded.get().getState().get("key"));
+
+        // 2. Try to insert same checkpoint ID with different state
+        var modifiedCheckpoint = Checkpoint.builder()
+            .id("fixed-checkpoint-id") // same ID!
+            .nodeId("node1")
+            .nextNodeId("node2")
+            .state(state2) // modified state
+            .build();
+
+        // config has no checkpointId, routes to insertedCheckpoint (allowOverwrite=false)
+        saver.put(config, modifiedCheckpoint);
+
+        // Verify state is still value1, because the conditional write prevented overwrite
+        var loaded2 = saver.get(getConfig);
+        assertEquals("value1", loaded2.get().getState().get("key"));
+
+        // 3. Now test updatedCheckpoint (allowOverwrite=true)
+        // config with checkpointId routes to updatedCheckpoint
+        saver.put(getConfig, modifiedCheckpoint);
+
+        // Verify state is now value2
+        var loaded3 = saver.get(getConfig);
+        assertEquals("value2", loaded3.get().getState().get("key"));
+
+        saver.deleteThread(threadId);
+    }
 }

--- a/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaverTest.java
+++ b/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/DynamoDBSaverTest.java
@@ -20,8 +20,16 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import org.testcontainers.containers.MinIOContainer;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.StreamSupport;
 import java.util.logging.LogManager;
@@ -85,6 +93,11 @@ public class DynamoDBSaverTest {
             .withFixedExposedPort(8344, DYNAMODB_PORT)
             .waitingFor(Wait.forLogMessage(".*Initializing DynamoDB Local.*\\n", 1));
 
+    @Container
+    static final MinIOContainer minioContainer = new MinIOContainer("minio/minio:latest")
+        .withUserName("minioadmin")
+        .withPassword("minioadmin");
+
     // ─── Lifecycle ───────────────────────────────────────────────────────────────
 
     @BeforeAll
@@ -95,11 +108,13 @@ public class DynamoDBSaverTest {
             }
         }
         assertTrue(dynamoContainer.isRunning(), "DynamoDB Local container should be running");
+        assertTrue(minioContainer.isRunning(), "MinIO container should be running");
     }
 
     @AfterAll
     static void shutdown() {
         dynamoContainer.close();
+        minioContainer.close();
     }
 
     // ─── Saver factory ───────────────────────────────────────────────────────────
@@ -112,13 +127,24 @@ public class DynamoDBSaverTest {
         String endpoint = "http://" + dynamoContainer.getHost()
                         + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
 
+        var client = software.amazon.awssdk.services.dynamodb.DynamoDbClient.builder()
+            .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+            .endpointOverride(java.net.URI.create(endpoint))
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy")))
+            .httpClientBuilder(ApacheHttpClient.builder()
+                // Prevent connection reset errors by aggressively expiring idle connections
+                .connectionMaxIdleTime(Duration.ofSeconds(1))
+                .connectionTimeToLive(Duration.ofSeconds(10))
+                .connectionTimeout(Duration.ofSeconds(5))
+                .socketTimeout(Duration.ofSeconds(5)))
+            .overrideConfiguration(b -> b
+                .apiCallAttemptTimeout(Duration.ofSeconds(6))
+                .apiCallTimeout(Duration.ofSeconds(20)))
+            .build();
+
         return DynamoDBSaver.builder()
             .tableName(TABLE_NAME)
-            .region("us-east-1")   // required by the SDK even for local DynamoDB
-            .endpointUrl(endpoint)
-            .credentialsProvider(  // DynamoDB Local accepts any non-null credentials
-                StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create("dummy", "dummy")))
+            .dynamoDbClient(client)
             .stateSerializer(param.stateSerializer)
             .dropTableFirst(true)
             .build();
@@ -133,13 +159,23 @@ public class DynamoDBSaverTest {
         String endpoint = "http://" + dynamoContainer.getHost()
                         + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
 
+        var client = software.amazon.awssdk.services.dynamodb.DynamoDbClient.builder()
+            .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+            .endpointOverride(java.net.URI.create(endpoint))
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy")))
+            .httpClientBuilder(ApacheHttpClient.builder()
+                .connectionMaxIdleTime(Duration.ofSeconds(1))
+                .connectionTimeToLive(Duration.ofSeconds(10))
+                .connectionTimeout(Duration.ofSeconds(5))
+                .socketTimeout(Duration.ofSeconds(5)))
+            .overrideConfiguration(b -> b
+                .apiCallAttemptTimeout(Duration.ofSeconds(6))
+                .apiCallTimeout(Duration.ofSeconds(20)))
+            .build();
+
         return DynamoDBSaver.builder()
             .tableName(TABLE_NAME)
-            .region("us-east-1")
-            .endpointUrl(endpoint)
-            .credentialsProvider(
-                StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create("dummy", "dummy")))
+            .dynamoDbClient(client)
             .stateSerializer(param.stateSerializer)
             .createTableIfNotExists(false)  // table already exists
             .build();
@@ -318,12 +354,15 @@ public class DynamoDBSaverTest {
         String endpoint = "http://" + dynamoContainer.getHost()
                         + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
 
+        var client = software.amazon.awssdk.services.dynamodb.DynamoDbClient.builder()
+            .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+            .endpointOverride(java.net.URI.create(endpoint))
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy")))
+            .build();
+
         var saver = DynamoDBSaver.builder()
             .tableName(TABLE_NAME)
-            .region("us-east-1")
-            .endpointUrl(endpoint)
-            .credentialsProvider(StaticCredentialsProvider.create(
-                AwsBasicCredentials.create("dummy", "dummy")))
+            .dynamoDbClient(client)
             .stateSerializer(new ObjectStreamStateSerializer<>(State::new))
             .dropTableFirst(true)
             .ttlSeconds(3600) // 1 hour — items will be available throughout the test
@@ -345,52 +384,6 @@ public class DynamoDBSaverTest {
         assertEquals(2, history.size());
 
         saver.release(runnableConfig);
-    }
-
-    /**
-     * Verify that a pre-built {@link software.amazon.awssdk.services.dynamodb.DynamoDbClient}
-     * injected via {@code .dynamoDbClient(...)} works correctly (e.g. for shared clients
-     * managed by the application container).
-     */
-    @Test
-    void testWithInjectedDynamoDbClient() throws Exception {
-        String endpoint = "http://" + dynamoContainer.getHost()
-                        + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
-
-        // Build the client externally
-        var externalClient = software.amazon.awssdk.services.dynamodb.DynamoDbClient.builder()
-            .region(software.amazon.awssdk.regions.Region.US_EAST_1)
-            .endpointOverride(java.net.URI.create(endpoint))
-            .credentialsProvider(StaticCredentialsProvider.create(
-                AwsBasicCredentials.create("dummy", "dummy")))
-            .build();
-
-        var saver = DynamoDBSaver.builder()
-            .tableName(TABLE_NAME)
-            .stateSerializer(new ObjectStreamStateSerializer<>(State::new))
-            .dynamoDbClient(externalClient)  // inject — region/endpoint settings ignored
-            .dropTableFirst(true)
-            .build();
-
-        var compileConfig = CompileConfig.builder()
-            .checkpointSaver(saver)
-            .releaseThread(false)
-            .build();
-
-        var runnableConfig = RunnableConfig.builder().threadId("thread-injected-client").build();
-        var workflow = singleNodeGraph().compile(compileConfig);
-
-        var result = workflow.invoke(Map.of("input", "injected-client"), runnableConfig);
-        assertTrue(result.isPresent());
-
-        var history = workflow.getStateHistory(runnableConfig);
-        assertFalse(history.isEmpty(), "Checkpoints must persist with injected client");
-        assertEquals(2, history.size());
-
-        saver.release(runnableConfig);
-
-        // Caller is responsible for closing the externally managed client
-        externalClient.close();
     }
 
     // ─── Phase 1.5 Tests ─────────────────────────────────────────────────────
@@ -620,5 +613,77 @@ public class DynamoDBSaverTest {
         assertEquals("value2", loaded3.get().getState().get("key"));
 
         saver.deleteThread(threadId);
+    }
+
+    /**
+     * Verify that payloads larger than 350KB are automatically offloaded to S3.
+     */
+    @Test
+    void testWithS3Offloading() throws Exception {
+        String dynamoEndpoint = "http://" + dynamoContainer.getHost()
+                        + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
+
+        var dynamoClient = software.amazon.awssdk.services.dynamodb.DynamoDbClient.builder()
+            .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+            .endpointOverride(java.net.URI.create(dynamoEndpoint))
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy")))
+            .build();
+
+        var s3Client = S3Client.builder()
+            .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+            .endpointOverride(java.net.URI.create(minioContainer.getS3URL()))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(minioContainer.getUserName(), minioContainer.getPassword())))
+            .forcePathStyle(true) // Required for MinIO
+            .build();
+
+        String s3Bucket = "test-checkpoints-bucket";
+        try {
+            s3Client.headBucket(HeadBucketRequest.builder().bucket(s3Bucket).build());
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                s3Client.createBucket(CreateBucketRequest.builder().bucket(s3Bucket).build());
+            } else {
+                throw e;
+            }
+        }
+
+        var saver = DynamoDBSaver.builder()
+            .tableName(TABLE_NAME)
+            .dynamoDbClient(dynamoClient)
+            .s3Bucket(s3Bucket)
+            .s3Client(s3Client)
+            .stateSerializer(new ObjectStreamStateSerializer<>(State::new))
+            .dropTableFirst(true)
+            .build();
+
+        var compileConfig = CompileConfig.builder()
+            .checkpointSaver(saver)
+            .releaseThread(false)
+            .build();
+
+        var threadId = "thread-s3-offload";
+        var runnableConfig = RunnableConfig.builder().threadId(threadId).build();
+        var workflow = singleNodeGraph().compile(compileConfig);
+
+        // Create a large payload > 350KB to trigger offload
+        byte[] largeData = new byte[400 * 1024];
+        Arrays.fill(largeData, (byte) 'a');
+        String largeString = new String(largeData, StandardCharsets.UTF_8);
+
+        var result = workflow.invoke(Map.of("input", largeString), runnableConfig);
+        assertTrue(result.isPresent());
+
+        // Verify history is retrievable (meaning it successfully fetches from S3)
+        var history = workflow.getStateHistory(runnableConfig);
+        assertFalse(history.isEmpty(), "History must be retrievable");
+        
+        // Ensure state contains largeString
+        var lastState = workflow.lastStateOf(runnableConfig).orElseThrow();
+        assertEquals(largeString, lastState.state().value("input").orElse(""));
+
+        // Cleanup
+        saver.deleteThread(threadId);
+        s3Client.close();
     }
 }

--- a/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/StorageStrategyTest.java
+++ b/langgraph4j-dynamodb-saver/src/test/java/org/bsc/langgraph4j/checkpoint/StorageStrategyTest.java
@@ -1,0 +1,226 @@
+package org.bsc.langgraph4j.checkpoint;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.MinIOContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Testcontainers
+public class StorageStrategyTest {
+
+    // ─── Container setup ─────────────────────────────────────────────────────────
+
+    private static final int DYNAMODB_PORT = 8000;
+    private static final String TABLE_NAME = "lg4j-test-chunks";
+    private static final String S3_BUCKET = "test-checkpoints-bucket";
+
+    @Container
+    static final FixedHostPortGenericContainer<?> dynamoContainer =
+        new FixedHostPortGenericContainer<>("amazon/dynamodb-local:latest")
+            .withFixedExposedPort(8345, DYNAMODB_PORT) // Different port to avoid conflict
+            .waitingFor(Wait.forLogMessage(".*Initializing DynamoDB Local.*\\n", 1));
+
+    @Container
+    static final MinIOContainer minioContainer = new MinIOContainer("minio/minio:latest")
+        .withUserName("minioadmin")
+        .withPassword("minioadmin");
+
+    private static DynamoDbClient dynamoDbClient;
+    private static S3Client s3Client;
+    private static DynamoDBRepository repository;
+
+    @BeforeAll
+    static void init() {
+        assertTrue(dynamoContainer.isRunning());
+        assertTrue(minioContainer.isRunning());
+
+        String dynamoEndpoint = "http://" + dynamoContainer.getHost()
+                              + ":" + dynamoContainer.getMappedPort(DYNAMODB_PORT);
+
+        dynamoDbClient = DynamoDbClient.builder()
+            .region(Region.US_EAST_1)
+            .endpointOverride(URI.create(dynamoEndpoint))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("dummy", "dummy")))
+            .build();
+
+        s3Client = S3Client.builder()
+            .region(Region.US_EAST_1)
+            .endpointOverride(URI.create(minioContainer.getS3URL()))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(minioContainer.getUserName(), minioContainer.getPassword())))
+            .forcePathStyle(true) // Required for MinIO
+            .build();
+
+        // Ensure bucket exists
+        try {
+            s3Client.headBucket(HeadBucketRequest.builder().bucket(S3_BUCKET).build());
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                s3Client.createBucket(CreateBucketRequest.builder().bucket(S3_BUCKET).build());
+            } else {
+                throw e;
+            }
+        }
+
+        // Setup generic repo just to create the table
+        repository = new DynamoDBRepository(dynamoDbClient, TABLE_NAME, null, null);
+        repository.createTableIfNotExists();
+    }
+
+    @AfterAll
+    static void shutdown() {
+        if (dynamoDbClient != null) dynamoDbClient.close();
+        if (s3Client != null) s3Client.close();
+        dynamoContainer.close();
+        minioContainer.close();
+    }
+
+    // ─── Unit Tests (Threshold Logic) ──────────────────────────────────────────
+
+    @Test
+    void testShouldOffloadToS3_belowThreshold() {
+        StorageStrategy strategy = new StorageStrategy(null, TABLE_NAME, s3Client, S3_BUCKET, null, null);
+        byte[] data = new byte[100 * 1024]; // 100KB
+        assertFalse(strategy.shouldOffloadToS3(data), "100KB should not trigger S3 offload");
+    }
+
+    @Test
+    void testShouldOffloadToS3_aboveThreshold() {
+        StorageStrategy strategy = new StorageStrategy(null, TABLE_NAME, s3Client, S3_BUCKET, null, null);
+        byte[] data = new byte[400 * 1024]; // 400KB
+        assertTrue(strategy.shouldOffloadToS3(data), "400KB should trigger S3 offload");
+    }
+
+    @Test
+    void testShouldOffloadToS3_s3Disabled() {
+        StorageStrategy strategy = new StorageStrategy(null, TABLE_NAME, null, null, null, null);
+        byte[] data = new byte[400 * 1024]; // 400KB
+        assertFalse(strategy.shouldOffloadToS3(data), "Should not offload if S3 is disabled");
+    }
+
+    // ─── Integration Tests (Store/Retrieve/Delete) ─────────────────────────────
+
+    @Test
+    void testSmallPayloadStaysInDynamoDB() {
+        StorageStrategy strategy = new StorageStrategy(dynamoDbClient, TABLE_NAME, s3Client, S3_BUCKET, "test-prefix", null);
+        
+        String chunkKey = "chunk-small-test";
+        String s3Key = "s3-small-test";
+        byte[] data = "Hello DynamoDB".getBytes();
+
+        String refLoc = strategy.storeData(chunkKey, s3Key, data, false);
+        assertEquals("DYNAMODB", refLoc);
+
+        // Retrieve should work
+        byte[] retrieved = strategy.retrieveData(chunkKey, refLoc);
+        assertNotNull(retrieved);
+        assertArrayEquals(data, retrieved);
+
+        // Batch delete should work
+        Map<String, List<String>> failed = strategy.batchDeleteData(java.util.Collections.singletonList(new String[]{chunkKey, refLoc}));
+        assertTrue(failed.get("failed").isEmpty());
+
+        // Should be gone
+        assertNull(strategy.retrieveData(chunkKey, refLoc));
+    }
+
+    @Test
+    void testLargePayloadRoutedToS3() {
+        StorageStrategy strategy = new StorageStrategy(dynamoDbClient, TABLE_NAME, s3Client, S3_BUCKET, "test-prefix", null);
+        
+        String chunkKey = "chunk-large-test";
+        String s3Key = "s3-large-test";
+        byte[] data = new byte[StorageStrategy.S3_OFFLOAD_THRESHOLD + 10];
+        data[0] = 1;
+        data[data.length - 1] = 2;
+
+        String refLoc = strategy.storeData(chunkKey, s3Key, data, false);
+        assertEquals("S3", refLoc);
+
+        // Retrieve should work
+        byte[] retrieved = strategy.retrieveData(s3Key, refLoc);
+        assertNotNull(retrieved);
+        assertArrayEquals(data, retrieved);
+
+        // Batch delete should work
+        Map<String, List<String>> failed = strategy.batchDeleteData(java.util.Collections.singletonList(new String[]{s3Key, refLoc}));
+        assertTrue(failed.get("failed").isEmpty());
+
+        // Should be gone
+        assertNull(strategy.retrieveData(s3Key, refLoc));
+    }
+
+    @Test
+    void testAllowOverwriteConditionalWriteS3() {
+        StorageStrategy strategy = new StorageStrategy(dynamoDbClient, TABLE_NAME, s3Client, S3_BUCKET, null, null);
+        String chunkKey = "chunk-cond";
+        String s3Key = "s3-cond";
+        byte[] data1 = new byte[StorageStrategy.S3_OFFLOAD_THRESHOLD + 10];
+        data1[0] = 1;
+        byte[] data2 = new byte[StorageStrategy.S3_OFFLOAD_THRESHOLD + 10];
+        data2[0] = 2;
+
+        // First write succeeds
+        strategy.storeData(chunkKey, s3Key, data1, false);
+
+        // Second write with allowOverwrite=false should be ignored (silently skipped in StorageStrategy)
+        strategy.storeData(chunkKey, s3Key, data2, false);
+
+        byte[] retrieved = strategy.retrieveData(s3Key, "S3");
+        assertEquals(1, retrieved[0], "Should retain first data");
+
+        // Third write with allowOverwrite=true should overwrite
+        strategy.storeData(chunkKey, s3Key, data2, true);
+        
+        retrieved = strategy.retrieveData(s3Key, "S3");
+        assertEquals(2, retrieved[0], "Should overwrite data");
+    }
+
+    @Test
+    void testAllowOverwriteConditionalWriteDynamoDB() {
+        StorageStrategy strategy = new StorageStrategy(dynamoDbClient, TABLE_NAME, s3Client, S3_BUCKET, null, null);
+        String chunkKey = "chunk-cond-dyn";
+        String s3Key = "s3-cond-dyn";
+        byte[] data1 = "data1".getBytes();
+        byte[] data2 = "data2".getBytes();
+
+        // First write succeeds
+        strategy.storeData(chunkKey, s3Key, data1, false);
+
+        // Second write with allowOverwrite=false should be ignored
+        strategy.storeData(chunkKey, s3Key, data2, false);
+
+        byte[] retrieved = strategy.retrieveData(chunkKey, "DYNAMODB");
+        assertArrayEquals(data1, retrieved, "Should retain first data");
+
+        // Third write with allowOverwrite=true should overwrite
+        strategy.storeData(chunkKey, s3Key, data2, true);
+        
+        retrieved = strategy.retrieveData(chunkKey, "DYNAMODB");
+        assertArrayEquals(data2, retrieved, "Should overwrite data");
+    }
+
+}


### PR DESCRIPTION
- Added StorageStrategy class to manage data storage between DynamoDB and S3 based on payload size.
- Implemented methods for storing, retrieving, and deleting data from both storage backends.
- Introduced lifecycle management for S3 objects with TTL support.
- Created unit tests for StorageStrategy to validate threshold logic and storage operations.
- Added DynamoDBRepositoryTest to verify key generation functions.
- Enhanced DynamoDBSaverTest with additional tests for thread deletion and conditional writes.
- Integrated MinIO for S3 testing and configured DynamoDB local instance for integration tests.
- Batch delete items in dynamo DB 
- Conditional writes in dynamo db