### PR TITLE
feat(core): expose null-safe nodeId() on GraphRunnerException

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/GraphRunnerException.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/GraphRunnerException.java
@@ -1,5 +1,7 @@
 package org.bsc.langgraph4j;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -17,10 +19,26 @@ public class GraphRunnerException extends Exception {
 
     public GraphRunnerException(RunnableConfig config, Throwable cause ) {
         super(cause);
-        this.config = requireNonNull(config, "config cannot be null");;
+        this.config = requireNonNull(config, "config cannot be null");
     }
 
     public RunnableConfig config() {
         return config;
+    }
+
+    /**
+     * Returns the identifier of the node that was being executed when the error occurred.
+     * <p>
+     * The value is resolved from the {@link RunnableConfig} carried by this exception
+     * (metadata key {@link RunnableConfig#NODE_ID}). Unlike {@link RunnableConfig#nodeId()},
+     * which throws when no node id is present, this accessor returns an empty {@link Optional}
+     * when the failure happens outside the scope of a specific node (for example, during
+     * entry-point resolution), so it is safe to call while handling a failure.
+     *
+     * @return an {@link Optional} containing the failing node id, or empty if it cannot be determined
+     * @since 1.9.0
+     */
+    public Optional<String> nodeId() {
+        return config.metadata(RunnableConfig.NODE_ID).map(Object::toString);
     }
 }

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/GraphRunnerExceptionTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/GraphRunnerExceptionTest.java
@@ -1,0 +1,86 @@
+package org.bsc.langgraph4j;
+
+import org.bsc.langgraph4j.action.AsyncNodeAction;
+import org.bsc.langgraph4j.state.AgentState;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.bsc.langgraph4j.GraphDefinition.END;
+import static org.bsc.langgraph4j.GraphDefinition.START;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link GraphRunnerException} surfaces the failing node id so callers can
+ * react to execution failures without inspecting the underlying {@link RunnableConfig}
+ * metadata directly, and without the {@code orElseThrow} of {@link RunnableConfig#nodeId()}.
+ *
+ * @see <a href="https://github.com/langgraph4j/langgraph4j/issues/90">Issue #90</a>
+ */
+public class GraphRunnerExceptionTest {
+
+    /**
+     * Walks the cause chain looking for a {@link GraphRunnerException}.
+     *
+     * @param throwable the throwable to inspect
+     * @return the first {@link GraphRunnerException} found, or empty
+     */
+    private static Optional<GraphRunnerException> findGraphRunnerException(Throwable throwable) {
+        for (Throwable current = throwable; current != null && current != current.getCause(); current = current.getCause()) {
+            if (current instanceof GraphRunnerException graphRunnerException) {
+                return Optional.of(graphRunnerException);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Test
+    public void nodeIdIsResolvedFromConfigMetadata() {
+        var config = RunnableConfig.builder()
+                .addMetadata(RunnableConfig.NODE_ID, "agent")
+                .build();
+
+        var exception = new GraphRunnerException(config, "boom");
+
+        assertEquals(Optional.of("agent"), exception.nodeId());
+    }
+
+    @Test
+    public void nodeIdIsEmptyWhenContextIsAbsent() {
+        var exception = new GraphRunnerException(RunnableConfig.builder().build(), "boom");
+
+        assertTrue(exception.nodeId().isEmpty());
+    }
+
+    @Test
+    public void failingNodeIsReportedOnGraphExecution() throws Exception {
+        var workflow = new StateGraph<>(AgentState::new)
+                .addNode("A", AsyncNodeAction.node_async(state -> Map.of()))
+                .addNode("B", AsyncNodeAction.node_async(state -> {
+                    throw new RuntimeException("boom");
+                }))
+                .addEdge(START, "A")
+                .addEdge("A", "B")
+                .addEdge("B", END)
+                .compile();
+
+        var thrown = assertThrows(Exception.class, () -> workflow.invoke(Map.of()));
+
+        var graphRunnerException = findGraphRunnerException(thrown)
+                .orElseThrow(() -> new AssertionError("expected a GraphRunnerException in the cause chain", thrown));
+
+        assertEquals(Optional.of("B"), graphRunnerException.nodeId());
+
+        var rootCause = graphRunnerException.getCause();
+        assertNotNull(rootCause);
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+            rootCause = rootCause.getCause();
+        }
+        assertEquals(RuntimeException.class, rootCause.getClass());
+        assertEquals("boom", rootCause.getMessage());
+    }
+}

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/exception/SubGraphInterruptionException.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/exception/SubGraphInterruptionException.java
@@ -40,8 +40,9 @@ public class SubGraphInterruptionException extends GraphRunnerException {
         return parentNodeId;
     }
 
-    public String nodeId() {
-        return nodeId;
+    @Override
+    public Optional<String> nodeId() {
+        return Optional.ofNullable(nodeId);
     }
 
     public Map<String, Object> state() {


### PR DESCRIPTION
Closes #90

When a node fails during graph execution, the error is wrapped in a
`GraphRunnerException`. The failing node is reachable via the carried
`RunnableConfig`, but `RunnableConfig.nodeId()` calls `orElseThrow()`, so
`config().nodeId()` throws when the exception is raised outside a node context
(e.g. entry-point resolution).

This adds `GraphRunnerException.nodeId()` returning `Optional<String>`, resolved
from the carried config and safe to call while handling a failure. The signature
follows `RunnableConfig`'s convention of returning `Optional` for absent values;
`SubGraphInterruptionException.nodeId()` (test source) is updated to match.

`checkPointId` is intentionally not added, since `config().checkPointId()` already
returns an `Optional<String>`.

## Tests
`GraphRunnerExceptionTest` covers resolution from config metadata, the empty case
when no node context is present, and an end-to-end run where a node throws and the
surfaced exception reports the failing node id.
