### PR TITLE
docs(how-tos): add Basic Reflection notebook (related to #8)

### DIFF
--- a/generator/gen_basic_reflection_nb.py
+++ b/generator/gen_basic_reflection_nb.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Generate how-tos/basic-reflection.ipynb (stub + optional LLM modes)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def md(s: str) -> dict:
+    lines = s.strip("\n").split("\n")
+    return {"cell_type": "markdown", "metadata": {}, "source": [l + "\n" for l in lines]}
+
+
+def code_lines(*lines: str) -> dict:
+    return {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [line + "\n" for line in lines],
+    }
+
+
+cells: list[dict] = []
+
+cells.append(
+    md(
+        """
+# Basic Reflection
+
+Port of the LangGraph [Reflection](https://langchain-ai.github.io/langgraph/tutorials/reflection/reflection/) agent pattern to LangGraph4j.
+
+Related to [#8](https://github.com/langgraph4j/langgraph4j/issues/8).
+
+## Agentic Architecture
+
+```
+START → generate → reflect ──► (continue) → generate
+              ↑                 │
+              └─────────────────┘
+                                └──► END
+```
+
+| Node | Role |
+|------|------|
+| `generate` | Produce (or revise) a draft answer |
+| `reflect` | Critique the latest draft and suggest improvements |
+
+The loop stops after a fixed number of generate/reflect rounds (`MAX_ROUNDS`).
+
+Modes:
+
+1. **Stub** — deterministic draft/critique, no API key  
+2. **LLM** — LangChain4j `AiServices` writer + critic (`OPENAI_API_KEY`)
+"""
+    )
+)
+
+cells.append(
+    code_lines(
+        'var userHomeDir = System.getProperty("user.home");',
+        'var localRespoUrl = "file://" + userHomeDir + "/.m2/repository/";',
+        'var langchain4jVersion = "1.9.1";',
+        'var langchain4jbeta = "1.9.1-beta17";',
+        'var langgraph4jVersion = "1.8.22";',
+    )
+)
+
+cells.append(md("Remove installed package from Jupyter cache"))
+cells.append(
+    code_lines(
+        "%%bash ",
+        "rm -rf \\{userHomeDir}/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/org/bsc/langgraph4j",
+    )
+)
+
+cells.append(md("Add local Maven repo and resolve dependencies"))
+cells.append(
+    code_lines(
+        "%dependency /add-repo local \\{localRespoUrl} release|never snapshot|always",
+        "// %dependency /list-repos",
+        "%dependency /add org.slf4j:slf4j-jdk14:2.0.9",
+        "%dependency /add org.bsc.langgraph4j:langgraph4j-core:\\{langgraph4jVersion}",
+        "%dependency /add org.bsc.langgraph4j:langgraph4j-langchain4j:\\{langgraph4jVersion}",
+        "%dependency /add dev.langchain4j:langchain4j:\\{langchain4jVersion}",
+        "%dependency /add dev.langchain4j:langchain4j-open-ai:\\{langchain4jVersion}",
+        "%dependency /add net.sourceforge.plantuml:plantuml-mit:1.2024.8",
+        "",
+        "%dependency /resolve",
+    )
+)
+
+cells.append(md("**Initialize Logger**"))
+cells.append(
+    code_lines(
+        'try( var file = new java.io.FileInputStream("./logging.properties")) {',
+        "    java.util.logging.LogManager.getLogManager().readConfiguration( file );",
+        "}",
+        "",
+        'var log = org.slf4j.LoggerFactory.getLogger("BasicReflection");',
+    )
+)
+
+cells.append(md("**Utility to render graph representation in PlantUML**"))
+cells.append(
+    code_lines(
+        "import net.sourceforge.plantuml.SourceStringReader;",
+        "import net.sourceforge.plantuml.FileFormatOption;",
+        "import net.sourceforge.plantuml.FileFormat;",
+        "",
+        "java.awt.Image plantUML2PNG( String code ) throws IOException { ",
+        "    var reader = new SourceStringReader(code);",
+        "",
+        "    try(var imageOutStream = new java.io.ByteArrayOutputStream()) {",
+        "",
+        "        var description = reader.outputImage( imageOutStream, 0, new FileFormatOption(FileFormat.PNG));",
+        "",
+        "        var imageInStream = new java.io.ByteArrayInputStream(  imageOutStream.toByteArray() );",
+        "",
+        "        return javax.imageio.ImageIO.read( imageInStream );",
+        "",
+        "    }",
+        "}",
+    )
+)
+
+cells.append(
+    md(
+        """
+## 1. Define the State
+
+Message list accumulates: user topic → draft → critique → revised draft → …
+"""
+    )
+)
+
+cells.append(
+    code_lines(
+        "import org.bsc.langgraph4j.prebuilt.MessagesState;",
+        "import org.bsc.langgraph4j.state.Channel;",
+        "",
+        "import java.util.List;",
+        "import java.util.Map;",
+        "",
+        "final int MAX_ROUNDS = 2;",
+        "",
+        "class ReflectionState extends MessagesState<String> {",
+        "",
+        "    public static final Map<String, Channel<?>> SCHEMA = MessagesState.SCHEMA;",
+        "",
+        "    public ReflectionState(Map<String, Object> initData) {",
+        "        super(initData);",
+        "    }",
+        "",
+        "    public String topic() {",
+        "        var msgs = messages();",
+        '        return msgs.isEmpty() ? "" : msgs.get(0);',
+        "    }",
+        "",
+        "    public long draftCount() {",
+        "        return messages().stream().filter(m -> m.startsWith(\"DRAFT:\")).count();",
+        "    }",
+        "",
+        "    public String lastMessageOrEmpty() {",
+        '        return lastMessage().orElse("");',
+        "    }",
+        "}",
+    )
+)
+
+cells.append(md("## 2. Routing"))
+cells.append(
+    code_lines(
+        "import org.bsc.langgraph4j.action.EdgeAction;",
+        "",
+        "EdgeAction<ReflectionState> shouldContinue = state ->",
+        '        state.draftCount() >= MAX_ROUNDS ? "end" : "continue";',
+    )
+)
+
+cells.append(
+    md(
+        """
+## 3. Stub mode (no API key)
+"""
+    )
+)
+
+cells.append(
+    code_lines(
+        "import org.bsc.langgraph4j.action.NodeAction;",
+        "",
+        "class StubGenerateNode implements NodeAction<ReflectionState> {",
+        "    @Override",
+        "    public Map<String, Object> apply(ReflectionState state) {",
+        "        var round = state.draftCount() + 1;",
+        "        var critique = state.messages().stream()",
+        '                .filter(m -> m.startsWith("CRITIQUE:"))',
+        '                .reduce((a, b) -> b)',
+        '                .orElse("");',
+        "        var draft = critique.isBlank()",
+        '                ? "DRAFT: (round " + round + ") An initial essay about: " + state.topic()',
+        '                : "DRAFT: (round " + round + ") Revised essay about: " + state.topic()',
+        '                  + " | addressing: " + critique.substring("CRITIQUE:".length()).trim();',
+        '        log.info("stub generate: {}", draft);',
+        '        return Map.of("messages", draft);',
+        "    }",
+        "}",
+        "",
+        "class StubReflectNode implements NodeAction<ReflectionState> {",
+        "    @Override",
+        "    public Map<String, Object> apply(ReflectionState state) {",
+        "        var draft = state.lastMessageOrEmpty();",
+        '        var critique = "CRITIQUE: Add a concrete example and a clearer conclusion for: " + draft;',
+        '        log.info("stub reflect: {}", critique);',
+        '        return Map.of("messages", critique);',
+        "    }",
+        "}",
+    )
+)
+
+cells.append(md("### Build / visualize / run stub graph"))
+cells.append(
+    code_lines(
+        "import org.bsc.langgraph4j.StateGraph;",
+        "import org.bsc.langgraph4j.GraphRepresentation;",
+        "import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;",
+        "import static org.bsc.langgraph4j.action.AsyncEdgeAction.edge_async;",
+        "import static org.bsc.langgraph4j.StateGraph.START;",
+        "import static org.bsc.langgraph4j.StateGraph.END;",
+        "",
+        "var stubWorkflow = new StateGraph<>(ReflectionState.SCHEMA, ReflectionState::new)",
+        '        .addNode("generate", node_async(new StubGenerateNode()))',
+        '        .addNode("reflect", node_async(new StubReflectNode()))',
+        '        .addEdge(START, "generate")',
+        '        .addEdge("generate", "reflect")',
+        '        .addConditionalEdges("reflect", edge_async(shouldContinue), Map.of(',
+        '                "continue", "generate",',
+        '                "end", END',
+        "        ));",
+        "",
+        "var stubApp = stubWorkflow.compile();",
+        "",
+        'var representation = stubWorkflow.getGraph(GraphRepresentation.Type.PLANTUML, "basic-reflection (stub)", false);',
+        "display(plantUML2PNG(representation.getContent()));",
+        "",
+        "var stubInput = Map.<String,Object>of(",
+        '        "messages", "Write a short essay about the benefits of journaling."',
+        ");",
+        "for (var event : stubApp.stream(stubInput)) {",
+        '    log.info("STUB STEP: {}", event);',
+        "}",
+    )
+)
+
+cells.append(
+    md(
+        """
+## 4. LLM mode (LangChain4j AiServices)
+
+Requires `OPENAI_API_KEY`. Two roles:
+
+* **Writer** — generate/revise the essay  
+* **Critic** — reflect on the latest draft
+"""
+    )
+)
+
+cells.append(
+    code_lines(
+        "import dev.langchain4j.model.chat.ChatModel;",
+        "import dev.langchain4j.model.openai.OpenAiChatModel;",
+        "import dev.langchain4j.service.AiServices;",
+        "import dev.langchain4j.service.SystemMessage;",
+        "import dev.langchain4j.service.UserMessage;",
+        "",
+        "import java.time.Duration;",
+        "import java.util.stream.Collectors;",
+        "",
+        'var openAiKey = System.getenv("OPENAI_API_KEY");',
+        "var llmEnabled = openAiKey != null && !openAiKey.isBlank();",
+        'log.info("LLM mode enabled: {}", llmEnabled);',
+        "",
+        "ChatModel chatModel = null;",
+        "if (llmEnabled) {",
+        "    chatModel = OpenAiChatModel.builder()",
+        "            .apiKey(openAiKey)",
+        '            .modelName("gpt-4o-mini")',
+        "            .timeout(Duration.ofMinutes(2))",
+        "            .logRequests(true)",
+        "            .logResponses(true)",
+        "            .maxRetries(2)",
+        "            .temperature(0.2)",
+        "            .maxTokens(1500)",
+        "            .build();",
+        "}",
+        "",
+        "interface WriterService {",
+        '    @SystemMessage("You are an essay writer. Produce a concise essay draft. "',
+        '            + "If critique feedback is provided, revise the previous draft accordingly. "',
+        '            + "Return only the essay text.")',
+        "    String write(@UserMessage String prompt);",
+        "}",
+        "",
+        "interface CriticService {",
+        '    @SystemMessage("You are a writing critic. Give brief, actionable critique "',
+        '            + "(structure, clarity, examples, conclusion). Return only the critique.")',
+        "    String critique(@UserMessage String draft);",
+        "}",
+        "",
+        "String conversationContext(ReflectionState state) {",
+        "    return state.messages().stream().collect(Collectors.joining(\"\\n\"));",
+        "}",
+    )
+)
+
+cells.append(
+    code_lines(
+        "class LlmGenerateNode implements NodeAction<ReflectionState> {",
+        "    private final WriterService writer;",
+        "",
+        "    LlmGenerateNode(ChatModel model) {",
+        "        this.writer = AiServices.create(WriterService.class, model);",
+        "    }",
+        "",
+        "    @Override",
+        "    public Map<String, Object> apply(ReflectionState state) {",
+        '        var prompt = "Topic / conversation so far:\\n" + conversationContext(state)',
+        '                + "\\n\\nWrite or revise the essay now.";',
+        "        var essay = writer.write(prompt);",
+        '        var draft = "DRAFT: " + essay;',
+        '        log.info("llm generate round={}", state.draftCount() + 1);',
+        '        return Map.of("messages", draft);',
+        "    }",
+        "}",
+        "",
+        "class LlmReflectNode implements NodeAction<ReflectionState> {",
+        "    private final CriticService critic;",
+        "",
+        "    LlmReflectNode(ChatModel model) {",
+        "        this.critic = AiServices.create(CriticService.class, model);",
+        "    }",
+        "",
+        "    @Override",
+        "    public Map<String, Object> apply(ReflectionState state) {",
+        "        var draft = state.lastMessageOrEmpty();",
+        '        var text = draft.startsWith("DRAFT:") ? draft.substring("DRAFT:".length()).trim() : draft;',
+        "        var critique = critic.critique(text);",
+        '        log.info("llm reflect");',
+        '        return Map.of("messages", "CRITIQUE: " + critique);',
+        "    }",
+        "}",
+    )
+)
+
+cells.append(
+    md(
+        """
+### Build / run LLM graph
+
+Skipped when `OPENAI_API_KEY` is unset.
+"""
+    )
+)
+
+cells.append(
+    code_lines(
+        "if (!llmEnabled) {",
+        '    log.warn("Skipping LLM graph — set OPENAI_API_KEY to enable.");',
+        "} else {",
+        "    var llmWorkflow = new StateGraph<>(ReflectionState.SCHEMA, ReflectionState::new)",
+        '            .addNode("generate", node_async(new LlmGenerateNode(chatModel)))',
+        '            .addNode("reflect", node_async(new LlmReflectNode(chatModel)))',
+        '            .addEdge(START, "generate")',
+        '            .addEdge("generate", "reflect")',
+        '            .addConditionalEdges("reflect", edge_async(shouldContinue), Map.of(',
+        '                    "continue", "generate",',
+        '                    "end", END',
+        "            ));",
+        "",
+        "    var llmApp = llmWorkflow.compile();",
+        "    var llmRepresentation = llmWorkflow.getGraph(",
+        '            GraphRepresentation.Type.PLANTUML, "basic-reflection (llm)", false);',
+        "    display(plantUML2PNG(llmRepresentation.getContent()));",
+        "",
+        "    var llmInput = Map.<String,Object>of(",
+        '            "messages", "Write a short essay about the benefits of journaling."',
+        "    );",
+        "    for (var event : llmApp.stream(llmInput)) {",
+        '        log.info("LLM STEP: {}", event);',
+        "    }",
+        "}",
+    )
+)
+
+cells.append(
+    md(
+        """
+## 5. Next steps
+
+* Tune `MAX_ROUNDS` or stop when the critic says the draft is good enough  
+* Persist with `MemorySaver` (`persistence.ipynb`)  
+* More [#8](https://github.com/langgraph4j/langgraph4j/issues/8) ports: Self-RAG, Reflexion, Plan-and-Execute
+"""
+    )
+)
+
+nb = {
+    "nbformat": 4,
+    "nbformat_minor": 5,
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Java (rapaio)",
+            "language": "java",
+            "name": "rapaio-jupyter-kernel",
+        },
+        "language_info": {"name": "java"},
+    },
+    "cells": cells,
+}
+
+path = Path(__file__).resolve().parents[1] / "how-tos" / "basic-reflection.ipynb"
+path.write_text(json.dumps(nb, indent=1, ensure_ascii=False) + "\n")
+print(f"wrote {path} cells={len(cells)}")

--- a/how-tos/basic-reflection.ipynb
+++ b/how-tos/basic-reflection.ipynb
@@ -1,0 +1,464 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Java (rapaio)",
+   "language": "java",
+   "name": "rapaio-jupyter-kernel"
+  },
+  "language_info": {
+   "name": "java"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic Reflection\n",
+    "\n",
+    "Port of the LangGraph [Reflection](https://langchain-ai.github.io/langgraph/tutorials/reflection/reflection/) agent pattern to LangGraph4j.\n",
+    "\n",
+    "Related to [#8](https://github.com/langgraph4j/langgraph4j/issues/8).\n",
+    "\n",
+    "## Agentic Architecture\n",
+    "\n",
+    "```\n",
+    "START → generate → reflect ──► (continue) → generate\n",
+    "              ↑                 │\n",
+    "              └─────────────────┘\n",
+    "                                └──► END\n",
+    "```\n",
+    "\n",
+    "| Node | Role |\n",
+    "|------|------|\n",
+    "| `generate` | Produce (or revise) a draft answer |\n",
+    "| `reflect` | Critique the latest draft and suggest improvements |\n",
+    "\n",
+    "The loop stops after a fixed number of generate/reflect rounds (`MAX_ROUNDS`).\n",
+    "\n",
+    "Modes:\n",
+    "\n",
+    "1. **Stub** — deterministic draft/critique, no API key  \n",
+    "2. **LLM** — LangChain4j `AiServices` writer + critic (`OPENAI_API_KEY`)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var userHomeDir = System.getProperty(\"user.home\");\n",
+    "var localRespoUrl = \"file://\" + userHomeDir + \"/.m2/repository/\";\n",
+    "var langchain4jVersion = \"1.9.1\";\n",
+    "var langchain4jbeta = \"1.9.1-beta17\";\n",
+    "var langgraph4jVersion = \"1.8.22\";\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Remove installed package from Jupyter cache\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash \n",
+    "rm -rf \\{userHomeDir}/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/org/bsc/langgraph4j\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add local Maven repo and resolve dependencies\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%dependency /add-repo local \\{localRespoUrl} release|never snapshot|always\n",
+    "// %dependency /list-repos\n",
+    "%dependency /add org.slf4j:slf4j-jdk14:2.0.9\n",
+    "%dependency /add org.bsc.langgraph4j:langgraph4j-core:\\{langgraph4jVersion}\n",
+    "%dependency /add org.bsc.langgraph4j:langgraph4j-langchain4j:\\{langgraph4jVersion}\n",
+    "%dependency /add dev.langchain4j:langchain4j:\\{langchain4jVersion}\n",
+    "%dependency /add dev.langchain4j:langchain4j-open-ai:\\{langchain4jVersion}\n",
+    "%dependency /add net.sourceforge.plantuml:plantuml-mit:1.2024.8\n",
+    "\n",
+    "%dependency /resolve\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Initialize Logger**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try( var file = new java.io.FileInputStream(\"./logging.properties\")) {\n",
+    "    java.util.logging.LogManager.getLogManager().readConfiguration( file );\n",
+    "}\n",
+    "\n",
+    "var log = org.slf4j.LoggerFactory.getLogger(\"BasicReflection\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Utility to render graph representation in PlantUML**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import net.sourceforge.plantuml.SourceStringReader;\n",
+    "import net.sourceforge.plantuml.FileFormatOption;\n",
+    "import net.sourceforge.plantuml.FileFormat;\n",
+    "\n",
+    "java.awt.Image plantUML2PNG( String code ) throws IOException { \n",
+    "    var reader = new SourceStringReader(code);\n",
+    "\n",
+    "    try(var imageOutStream = new java.io.ByteArrayOutputStream()) {\n",
+    "\n",
+    "        var description = reader.outputImage( imageOutStream, 0, new FileFormatOption(FileFormat.PNG));\n",
+    "\n",
+    "        var imageInStream = new java.io.ByteArrayInputStream(  imageOutStream.toByteArray() );\n",
+    "\n",
+    "        return javax.imageio.ImageIO.read( imageInStream );\n",
+    "\n",
+    "    }\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Define the State\n",
+    "\n",
+    "Message list accumulates: user topic → draft → critique → revised draft → …\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import org.bsc.langgraph4j.prebuilt.MessagesState;\n",
+    "import org.bsc.langgraph4j.state.Channel;\n",
+    "\n",
+    "import java.util.List;\n",
+    "import java.util.Map;\n",
+    "\n",
+    "final int MAX_ROUNDS = 2;\n",
+    "\n",
+    "class ReflectionState extends MessagesState<String> {\n",
+    "\n",
+    "    public static final Map<String, Channel<?>> SCHEMA = MessagesState.SCHEMA;\n",
+    "\n",
+    "    public ReflectionState(Map<String, Object> initData) {\n",
+    "        super(initData);\n",
+    "    }\n",
+    "\n",
+    "    public String topic() {\n",
+    "        var msgs = messages();\n",
+    "        return msgs.isEmpty() ? \"\" : msgs.get(0);\n",
+    "    }\n",
+    "\n",
+    "    public long draftCount() {\n",
+    "        return messages().stream().filter(m -> m.startsWith(\"DRAFT:\")).count();\n",
+    "    }\n",
+    "\n",
+    "    public String lastMessageOrEmpty() {\n",
+    "        return lastMessage().orElse(\"\");\n",
+    "    }\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Routing\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import org.bsc.langgraph4j.action.EdgeAction;\n",
+    "\n",
+    "EdgeAction<ReflectionState> shouldContinue = state ->\n",
+    "        state.draftCount() >= MAX_ROUNDS ? \"end\" : \"continue\";\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Stub mode (no API key)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import org.bsc.langgraph4j.action.NodeAction;\n",
+    "\n",
+    "class StubGenerateNode implements NodeAction<ReflectionState> {\n",
+    "    @Override\n",
+    "    public Map<String, Object> apply(ReflectionState state) {\n",
+    "        var round = state.draftCount() + 1;\n",
+    "        var critique = state.messages().stream()\n",
+    "                .filter(m -> m.startsWith(\"CRITIQUE:\"))\n",
+    "                .reduce((a, b) -> b)\n",
+    "                .orElse(\"\");\n",
+    "        var draft = critique.isBlank()\n",
+    "                ? \"DRAFT: (round \" + round + \") An initial essay about: \" + state.topic()\n",
+    "                : \"DRAFT: (round \" + round + \") Revised essay about: \" + state.topic()\n",
+    "                  + \" | addressing: \" + critique.substring(\"CRITIQUE:\".length()).trim();\n",
+    "        log.info(\"stub generate: {}\", draft);\n",
+    "        return Map.of(\"messages\", draft);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "class StubReflectNode implements NodeAction<ReflectionState> {\n",
+    "    @Override\n",
+    "    public Map<String, Object> apply(ReflectionState state) {\n",
+    "        var draft = state.lastMessageOrEmpty();\n",
+    "        var critique = \"CRITIQUE: Add a concrete example and a clearer conclusion for: \" + draft;\n",
+    "        log.info(\"stub reflect: {}\", critique);\n",
+    "        return Map.of(\"messages\", critique);\n",
+    "    }\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build / visualize / run stub graph\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import org.bsc.langgraph4j.StateGraph;\n",
+    "import org.bsc.langgraph4j.GraphRepresentation;\n",
+    "import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;\n",
+    "import static org.bsc.langgraph4j.action.AsyncEdgeAction.edge_async;\n",
+    "import static org.bsc.langgraph4j.StateGraph.START;\n",
+    "import static org.bsc.langgraph4j.StateGraph.END;\n",
+    "\n",
+    "var stubWorkflow = new StateGraph<>(ReflectionState.SCHEMA, ReflectionState::new)\n",
+    "        .addNode(\"generate\", node_async(new StubGenerateNode()))\n",
+    "        .addNode(\"reflect\", node_async(new StubReflectNode()))\n",
+    "        .addEdge(START, \"generate\")\n",
+    "        .addEdge(\"generate\", \"reflect\")\n",
+    "        .addConditionalEdges(\"reflect\", edge_async(shouldContinue), Map.of(\n",
+    "                \"continue\", \"generate\",\n",
+    "                \"end\", END\n",
+    "        ));\n",
+    "\n",
+    "var stubApp = stubWorkflow.compile();\n",
+    "\n",
+    "var representation = stubWorkflow.getGraph(GraphRepresentation.Type.PLANTUML, \"basic-reflection (stub)\", false);\n",
+    "display(plantUML2PNG(representation.getContent()));\n",
+    "\n",
+    "var stubInput = Map.<String,Object>of(\n",
+    "        \"messages\", \"Write a short essay about the benefits of journaling.\"\n",
+    ");\n",
+    "for (var event : stubApp.stream(stubInput)) {\n",
+    "    log.info(\"STUB STEP: {}\", event);\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. LLM mode (LangChain4j AiServices)\n",
+    "\n",
+    "Requires `OPENAI_API_KEY`. Two roles:\n",
+    "\n",
+    "* **Writer** — generate/revise the essay  \n",
+    "* **Critic** — reflect on the latest draft\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dev.langchain4j.model.chat.ChatModel;\n",
+    "import dev.langchain4j.model.openai.OpenAiChatModel;\n",
+    "import dev.langchain4j.service.AiServices;\n",
+    "import dev.langchain4j.service.SystemMessage;\n",
+    "import dev.langchain4j.service.UserMessage;\n",
+    "\n",
+    "import java.time.Duration;\n",
+    "import java.util.stream.Collectors;\n",
+    "\n",
+    "var openAiKey = System.getenv(\"OPENAI_API_KEY\");\n",
+    "var llmEnabled = openAiKey != null && !openAiKey.isBlank();\n",
+    "log.info(\"LLM mode enabled: {}\", llmEnabled);\n",
+    "\n",
+    "ChatModel chatModel = null;\n",
+    "if (llmEnabled) {\n",
+    "    chatModel = OpenAiChatModel.builder()\n",
+    "            .apiKey(openAiKey)\n",
+    "            .modelName(\"gpt-4o-mini\")\n",
+    "            .timeout(Duration.ofMinutes(2))\n",
+    "            .logRequests(true)\n",
+    "            .logResponses(true)\n",
+    "            .maxRetries(2)\n",
+    "            .temperature(0.2)\n",
+    "            .maxTokens(1500)\n",
+    "            .build();\n",
+    "}\n",
+    "\n",
+    "interface WriterService {\n",
+    "    @SystemMessage(\"You are an essay writer. Produce a concise essay draft. \"\n",
+    "            + \"If critique feedback is provided, revise the previous draft accordingly. \"\n",
+    "            + \"Return only the essay text.\")\n",
+    "    String write(@UserMessage String prompt);\n",
+    "}\n",
+    "\n",
+    "interface CriticService {\n",
+    "    @SystemMessage(\"You are a writing critic. Give brief, actionable critique \"\n",
+    "            + \"(structure, clarity, examples, conclusion). Return only the critique.\")\n",
+    "    String critique(@UserMessage String draft);\n",
+    "}\n",
+    "\n",
+    "String conversationContext(ReflectionState state) {\n",
+    "    return state.messages().stream().collect(Collectors.joining(\"\\n\"));\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LlmGenerateNode implements NodeAction<ReflectionState> {\n",
+    "    private final WriterService writer;\n",
+    "\n",
+    "    LlmGenerateNode(ChatModel model) {\n",
+    "        this.writer = AiServices.create(WriterService.class, model);\n",
+    "    }\n",
+    "\n",
+    "    @Override\n",
+    "    public Map<String, Object> apply(ReflectionState state) {\n",
+    "        var prompt = \"Topic / conversation so far:\\n\" + conversationContext(state)\n",
+    "                + \"\\n\\nWrite or revise the essay now.\";\n",
+    "        var essay = writer.write(prompt);\n",
+    "        var draft = \"DRAFT: \" + essay;\n",
+    "        log.info(\"llm generate round={}\", state.draftCount() + 1);\n",
+    "        return Map.of(\"messages\", draft);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "class LlmReflectNode implements NodeAction<ReflectionState> {\n",
+    "    private final CriticService critic;\n",
+    "\n",
+    "    LlmReflectNode(ChatModel model) {\n",
+    "        this.critic = AiServices.create(CriticService.class, model);\n",
+    "    }\n",
+    "\n",
+    "    @Override\n",
+    "    public Map<String, Object> apply(ReflectionState state) {\n",
+    "        var draft = state.lastMessageOrEmpty();\n",
+    "        var text = draft.startsWith(\"DRAFT:\") ? draft.substring(\"DRAFT:\".length()).trim() : draft;\n",
+    "        var critique = critic.critique(text);\n",
+    "        log.info(\"llm reflect\");\n",
+    "        return Map.of(\"messages\", \"CRITIQUE: \" + critique);\n",
+    "    }\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build / run LLM graph\n",
+    "\n",
+    "Skipped when `OPENAI_API_KEY` is unset.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if (!llmEnabled) {\n",
+    "    log.warn(\"Skipping LLM graph — set OPENAI_API_KEY to enable.\");\n",
+    "} else {\n",
+    "    var llmWorkflow = new StateGraph<>(ReflectionState.SCHEMA, ReflectionState::new)\n",
+    "            .addNode(\"generate\", node_async(new LlmGenerateNode(chatModel)))\n",
+    "            .addNode(\"reflect\", node_async(new LlmReflectNode(chatModel)))\n",
+    "            .addEdge(START, \"generate\")\n",
+    "            .addEdge(\"generate\", \"reflect\")\n",
+    "            .addConditionalEdges(\"reflect\", edge_async(shouldContinue), Map.of(\n",
+    "                    \"continue\", \"generate\",\n",
+    "                    \"end\", END\n",
+    "            ));\n",
+    "\n",
+    "    var llmApp = llmWorkflow.compile();\n",
+    "    var llmRepresentation = llmWorkflow.getGraph(\n",
+    "            GraphRepresentation.Type.PLANTUML, \"basic-reflection (llm)\", false);\n",
+    "    display(plantUML2PNG(llmRepresentation.getContent()));\n",
+    "\n",
+    "    var llmInput = Map.<String,Object>of(\n",
+    "            \"messages\", \"Write a short essay about the benefits of journaling.\"\n",
+    "    );\n",
+    "    for (var event : llmApp.stream(llmInput)) {\n",
+    "        log.info(\"LLM STEP: {}\", event);\n",
+    "    }\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Next steps\n",
+    "\n",
+    "* Tune `MAX_ROUNDS` or stop when the critic says the draft is good enough  \n",
+    "* Persist with `MemorySaver` (`persistence.ipynb`)  \n",
+    "* More [#8](https://github.com/langgraph4j/langgraph4j/issues/8) ports: Self-RAG, Reflexion, Plan-and-Execute\n"
+   ]
+  }
+ ]
+}

--- a/how-tos/src/site/markdown/basic-reflection.md
+++ b/how-tos/src/site/markdown/basic-reflection.md
@@ -1,0 +1,28 @@
+# Basic Reflection
+
+Port of the LangGraph [Reflection](https://langchain-ai.github.io/langgraph/tutorials/reflection/reflection/) pattern to LangGraph4j.
+
+Related to [#8](https://github.com/langgraph4j/langgraph4j/issues/8).
+
+See the interactive notebook: [`basic-reflection.ipynb`](../../basic-reflection.ipynb).
+
+## Architecture
+
+```
+START → generate → reflect ──► (continue) → generate
+              ↑                 │
+              └─────────────────┘
+                                └──► END
+```
+
+| Node | Role |
+|------|------|
+| `generate` | Produce or revise a draft |
+| `reflect` | Critique the latest draft |
+
+Stops after `MAX_ROUNDS` generate/reflect cycles.
+
+## Modes
+
+1. **Stub** — deterministic draft/critique (no API key). Covered by `BasicReflectionStubTest`.
+2. **LLM** — LangChain4j writer + critic. Requires `OPENAI_API_KEY`. Covered by `BasicReflectionITest`.

--- a/how-tos/src/site/markdown/index.md
+++ b/how-tos/src/site/markdown/index.md
@@ -6,6 +6,7 @@ They are a collection of how-to(_s_) for LangGraph4j implemented using the [Java
 
 * [Langchain4j Adaptive Rag](adaptiverag.md)
 * [Langchain4j Agent Executor](agentexecutor.md)
+* [Basic Reflection](basic-reflection.md)
 * [How to add persistence to your graph](persistence.md)
 * [How to view and update past graph state](time-travel.md)
 * [Wait for user input](wait-user-input.md)

--- a/how-tos/src/site/site.xml
+++ b/how-tos/src/site/site.xml
@@ -30,6 +30,7 @@
             <item name="Adaptive Rag" href="adaptiverag.html"/>
             <item name="Agent Executor" href="agentexecutor.html"/>
             <item name="Multi-agent supervisor" href="multi-agent-supervisor.html"/>
+            <item name="Basic Reflection" href="basic-reflection.html"/>
             <item name="How to add persistence to your graph" href="persistence.html"/>
             <item name="How to view and update past graph state" href="time-travel.html"/>
             <item name="Wait for user input" href="wait-user-input.html"/>

--- a/how-tos/src/test/java/org/bsc/langgraph4j/BasicReflectionITest.java
+++ b/how-tos/src/test/java/org/bsc/langgraph4j/BasicReflectionITest.java
@@ -1,0 +1,139 @@
+package org.bsc.langgraph4j;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import org.bsc.langgraph4j.action.EdgeAction;
+import org.bsc.langgraph4j.action.NodeAction;
+import org.bsc.langgraph4j.prebuilt.MessagesState;
+import org.bsc.langgraph4j.state.Channel;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.bsc.langgraph4j.StateGraph.END;
+import static org.bsc.langgraph4j.StateGraph.START;
+import static org.bsc.langgraph4j.action.AsyncEdgeAction.edge_async;
+import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Live LLM coverage for Basic Reflection (related to
+ * <a href="https://github.com/langgraph4j/langgraph4j/issues/8">#8</a>).
+ * Skipped unless {@code OPENAI_API_KEY} is set. Excluded from default Surefire via {@code *ITest}.
+ */
+public class BasicReflectionITest {
+
+    private static final org.slf4j.Logger log =
+            org.slf4j.LoggerFactory.getLogger(BasicReflectionITest.class);
+
+    static final int MAX_ROUNDS = 2;
+
+    static class ReflectionState extends MessagesState<String> {
+        static final Map<String, Channel<?>> SCHEMA = MessagesState.SCHEMA;
+
+        ReflectionState(Map<String, Object> initData) {
+            super(initData);
+        }
+
+        long draftCount() {
+            return messages().stream().filter(m -> m.startsWith("DRAFT:")).count();
+        }
+
+        String lastMessageOrEmpty() {
+            return lastMessage().orElse("");
+        }
+    }
+
+    interface WriterService {
+        @SystemMessage("You are an essay writer. Produce a concise essay draft. "
+                + "If critique feedback is provided, revise the previous draft accordingly. "
+                + "Return only the essay text.")
+        String write(@UserMessage String prompt);
+    }
+
+    interface CriticService {
+        @SystemMessage("You are a writing critic. Give brief, actionable critique "
+                + "(structure, clarity, examples, conclusion). Return only the critique.")
+        String critique(@UserMessage String draft);
+    }
+
+    static class LlmGenerateNode implements NodeAction<ReflectionState> {
+        private final WriterService writer;
+
+        LlmGenerateNode(ChatModel model) {
+            this.writer = AiServices.create(WriterService.class, model);
+        }
+
+        @Override
+        public Map<String, Object> apply(ReflectionState state) {
+            var prompt = "Topic / conversation so far:\n"
+                    + state.messages().stream().collect(Collectors.joining("\n"))
+                    + "\n\nWrite or revise the essay now.";
+            return Map.of("messages", "DRAFT: " + writer.write(prompt));
+        }
+    }
+
+    static class LlmReflectNode implements NodeAction<ReflectionState> {
+        private final CriticService critic;
+
+        LlmReflectNode(ChatModel model) {
+            this.critic = AiServices.create(CriticService.class, model);
+        }
+
+        @Override
+        public Map<String, Object> apply(ReflectionState state) {
+            var draft = state.lastMessageOrEmpty();
+            var text = draft.startsWith("DRAFT:") ? draft.substring("DRAFT:".length()).trim() : draft;
+            return Map.of("messages", "CRITIQUE: " + critic.critique(text));
+        }
+    }
+
+    @Test
+    void llmReflectionRunsFixedRounds() throws Exception {
+        var openAiKey = System.getenv("OPENAI_API_KEY");
+        Assumptions.assumeTrue(openAiKey != null && !openAiKey.isBlank(),
+                "OPENAI_API_KEY is required for BasicReflectionITest");
+
+        var chatModel = OpenAiChatModel.builder()
+                .apiKey(openAiKey)
+                .modelName("gpt-4o-mini")
+                .timeout(Duration.ofMinutes(2))
+                .logRequests(true)
+                .logResponses(true)
+                .maxRetries(2)
+                .temperature(0.2)
+                .maxTokens(1500)
+                .build();
+
+        EdgeAction<ReflectionState> shouldContinue = state ->
+                state.draftCount() >= MAX_ROUNDS ? "end" : "continue";
+
+        var app = new StateGraph<>(ReflectionState.SCHEMA, ReflectionState::new)
+                .addNode("generate", node_async(new LlmGenerateNode(chatModel)))
+                .addNode("reflect", node_async(new LlmReflectNode(chatModel)))
+                .addEdge(START, "generate")
+                .addEdge("generate", "reflect")
+                .addConditionalEdges("reflect", edge_async(shouldContinue), Map.of(
+                        "continue", "generate",
+                        "end", END
+                ))
+                .compile();
+
+        var result = app.invoke(Map.of(
+                "messages", "Write a short essay about the benefits of journaling."
+        ));
+
+        assertTrue(result.isPresent());
+        var state = result.get();
+        assertEquals(MAX_ROUNDS, state.draftCount());
+        assertTrue(state.messages().stream().anyMatch(m -> m.startsWith("CRITIQUE:")));
+        log.info("final messages:\n{}", state.messages());
+    }
+}

--- a/how-tos/src/test/java/org/bsc/langgraph4j/BasicReflectionStubTest.java
+++ b/how-tos/src/test/java/org/bsc/langgraph4j/BasicReflectionStubTest.java
@@ -1,0 +1,99 @@
+package org.bsc.langgraph4j;
+
+import org.bsc.langgraph4j.action.EdgeAction;
+import org.bsc.langgraph4j.action.NodeAction;
+import org.bsc.langgraph4j.prebuilt.MessagesState;
+import org.bsc.langgraph4j.state.Channel;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.bsc.langgraph4j.StateGraph.END;
+import static org.bsc.langgraph4j.StateGraph.START;
+import static org.bsc.langgraph4j.action.AsyncEdgeAction.edge_async;
+import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Skeleton coverage for the Basic Reflection how-to (related to
+ * <a href="https://github.com/langgraph4j/langgraph4j/issues/8">#8</a>).
+ */
+public class BasicReflectionStubTest {
+
+    static final int MAX_ROUNDS = 2;
+
+    static class ReflectionState extends MessagesState<String> {
+
+        static final Map<String, Channel<?>> SCHEMA = MessagesState.SCHEMA;
+
+        ReflectionState(Map<String, Object> initData) {
+            super(initData);
+        }
+
+        String topic() {
+            var msgs = messages();
+            return msgs.isEmpty() ? "" : msgs.get(0);
+        }
+
+        long draftCount() {
+            return messages().stream().filter(m -> m.startsWith("DRAFT:")).count();
+        }
+
+        String lastMessageOrEmpty() {
+            return lastMessage().orElse("");
+        }
+    }
+
+    static class StubGenerateNode implements NodeAction<ReflectionState> {
+        @Override
+        public Map<String, Object> apply(ReflectionState state) {
+            var round = state.draftCount() + 1;
+            var critique = state.messages().stream()
+                    .filter(m -> m.startsWith("CRITIQUE:"))
+                    .reduce((a, b) -> b)
+                    .orElse("");
+            var draft = critique.isBlank()
+                    ? "DRAFT: (round " + round + ") An initial essay about: " + state.topic()
+                    : "DRAFT: (round " + round + ") Revised essay about: " + state.topic()
+                    + " | addressing: " + critique.substring("CRITIQUE:".length()).trim();
+            return Map.of("messages", draft);
+        }
+    }
+
+    static class StubReflectNode implements NodeAction<ReflectionState> {
+        @Override
+        public Map<String, Object> apply(ReflectionState state) {
+            var draft = state.lastMessageOrEmpty();
+            return Map.of("messages",
+                    "CRITIQUE: Add a concrete example and a clearer conclusion for: " + draft);
+        }
+    }
+
+    @Test
+    void stubReflectionRunsFixedRounds() throws Exception {
+        EdgeAction<ReflectionState> shouldContinue = state ->
+                state.draftCount() >= MAX_ROUNDS ? "end" : "continue";
+
+        var app = new StateGraph<>(ReflectionState.SCHEMA, ReflectionState::new)
+                .addNode("generate", node_async(new StubGenerateNode()))
+                .addNode("reflect", node_async(new StubReflectNode()))
+                .addEdge(START, "generate")
+                .addEdge("generate", "reflect")
+                .addConditionalEdges("reflect", edge_async(shouldContinue), Map.of(
+                        "continue", "generate",
+                        "end", END
+                ))
+                .compile();
+
+        var result = app.invoke(Map.of(
+                "messages", "Write a short essay about the benefits of journaling."
+        ));
+
+        assertTrue(result.isPresent());
+        var state = result.get();
+        assertEquals(MAX_ROUNDS, state.draftCount());
+        assertTrue(state.messages().stream().anyMatch(m -> m.startsWith("CRITIQUE:")));
+        assertTrue(state.messages().size() >= 1 + MAX_ROUNDS * 2);
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Agent Executor: how-tos/agentexecutor.ipynb
       - Agent Executor with MCP: how-tos/agentexecutor-mcp.ipynb
       - Multi-agent supervisor: how-tos/multi-agent-supervisor.ipynb
+      - Basic Reflection: how-tos/basic-reflection.ipynb
       - Add persistence (“memory”) to your graph: how-tos/persistence.ipynb
       - View and Update past graph state: how-tos/time-travel.ipynb
       - Wait for User input: how-tos/wait-user-input.ipynb
@@ -88,6 +89,7 @@ nav:
       - Agent Executor: how-tos/agentexecutor.ipynb
       - Agent Executor with MCP: how-tos/agentexecutor-mcp.ipynb
       - Multi-agent supervisor: how-tos/multi-agent-supervisor.ipynb
+      - Basic Reflection: how-tos/basic-reflection.ipynb
       - Add persistence (“memory”) to your graph: how-tos/persistence.ipynb
       - View and Update past graph state: how-tos/time-travel.ipynb
       - Wait for User input: how-tos/wait-user-input.ipynb


### PR DESCRIPTION
## Summary
Adds a Basic Reflection how-to as requested in #8.

### What's included
- `how-tos/basic-reflection.ipynb` — generate → reflect loop + PlantUML
- Stub mode (default) + optional LangChain4j writer/critic (`OPENAI_API_KEY`)
- `BasicReflectionStubTest` / `BasicReflectionITest`
- Docs/nav updates

### Test
```bash
./mvnw -pl how-tos -am test -Dtest=BasicReflectionStubTest -Dsurefire.failIfNoSpecifiedTests=false