### PR TITLE
fix(AiMessageSerializer): always write/read text alongside tool execution requests

### DIFF
--- a/langchain4j/langchain4j-core/src/main/java/org/bsc/langgraph4j/langchain4j/serializer/std/AiMessageSerializer.java
+++ b/langchain4j/langchain4j-core/src/main/java/org/bsc/langgraph4j/langchain4j/serializer/std/AiMessageSerializer.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
-import org.bsc.langgraph4j.serializer.Serializer;
 import org.bsc.langgraph4j.serializer.std.NullableObjectSerializer;
 
 
@@ -35,12 +34,12 @@ public class AiMessageSerializer implements NullableObjectSerializer<AiMessage> 
 
         if( hasToolExecutionRequests ) {
             out.writeObject( object.toolExecutionRequests() );
-
-        }
-        else {
-            Serializer.writeUTF(object.text(), out);
         }
 
+        // text and tool execution requests are NOT mutually exclusive (e.g. Gemini and other
+        // providers can return both in the same turn) — always write text, regardless of whether
+        // tool execution requests are also present.
+        writeNullableUTF( object.text(), out );
     }
 
     /**
@@ -66,9 +65,8 @@ public class AiMessageSerializer implements NullableObjectSerializer<AiMessage> 
             List<ToolExecutionRequest> toolExecutionRequests = (List<ToolExecutionRequest>)in.readObject();
             builder.toolExecutionRequests( toolExecutionRequests );
         }
-        else {
-            builder.text( Serializer.readUTF(in) );
-        }
+
+        readNullableUTF(in).ifPresent( builder::text );
 
         return builder.build();
     }

--- a/langchain4j/langchain4j-core/src/test/java/org/bsc/langgraph4j/langchain4j/serializer/std/SerializationTest.java
+++ b/langchain4j/langchain4j-core/src/test/java/org/bsc/langgraph4j/langchain4j/serializer/std/SerializationTest.java
@@ -1,5 +1,6 @@
 package org.bsc.langgraph4j.langchain4j.serializer.std;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.*;
 import org.bsc.langgraph4j.prebuilt.MessagesState;
@@ -141,6 +142,86 @@ public class SerializationTest {
         };
 
 
+
+    }
+
+    @Test
+    public void AiMessageTextAndToolExecutionRequestsSerializerTest() throws Exception {
+
+        var aiMessage = AiMessage.builder()
+                .text( "Some message for the user" )
+                .toolExecutionRequests( List.of(
+                        ToolExecutionRequest.builder()
+                                .id( "1" )
+                                .name( "someTool" )
+                                .arguments( "{}" )
+                                .build()
+                ) )
+                .build();
+
+        var serializer = new LC4jStateSerializer<>(State::new);
+
+        var state = new State( Map.of(
+                "messages", List.of(aiMessage) )
+        );
+
+        try(var baos = new ByteArrayOutputStream(); var out = new ObjectOutputStream(baos) ) {
+
+            serializer.write(state, out);
+
+            try( var in = new ObjectInputStream( new ByteArrayInputStream(baos.toByteArray() )) ) {
+
+                var newState = serializer.read( in );
+
+                assertNotNull( newState );
+                assertEquals( 1, newState.messages().size());
+                var message = newState.messages().get( 0 );
+                assertInstanceOf( AiMessage.class, message );
+
+                var newAiMessage = (AiMessage)message;
+
+                assertEquals( aiMessage.text(), newAiMessage.text() );
+                assertEquals( aiMessage.toolExecutionRequests(), newAiMessage.toolExecutionRequests() );
+            }
+
+        };
+
+    }
+
+    @Test
+    public void AiMessageOnlyToolExecutionRequestsSerializerTest() throws Exception {
+
+        var aiMessage = AiMessage.builder()
+                .toolExecutionRequests( List.of(
+                        ToolExecutionRequest.builder()
+                                .id( "1" )
+                                .name( "someTool" )
+                                .arguments( "{}" )
+                                .build()
+                ) )
+                .build();
+
+        var serializer = new LC4jStateSerializer<>(State::new);
+
+        var state = new State( Map.of(
+                "messages", List.of(aiMessage) )
+        );
+
+        try(var baos = new ByteArrayOutputStream(); var out = new ObjectOutputStream(baos) ) {
+
+            serializer.write(state, out);
+
+            try( var in = new ObjectInputStream( new ByteArrayInputStream(baos.toByteArray() )) ) {
+
+                var newState = serializer.read( in );
+
+                var newAiMessage = (AiMessage)newState.messages().get( 0 );
+
+                assertNull( newAiMessage.text() );
+                assertEquals( aiMessage.toolExecutionRequests(), newAiMessage.toolExecutionRequests() );
+            }
+
+        };
 
     }
 }


### PR DESCRIPTION
Fixes #424

## Root cause
`AiMessageSerializer` treated `text` and `toolExecutionRequests` as mutually
exclusive on write: when `hasToolExecutionRequests()` was true, `text` was
never written, so it always comes back `null` after a round-trip — even
when the original message had both. Several providers (e.g. Gemini) return
a text part and a function-call part in the same turn; this silently drops
the model's message on any persisted state containing such a turn.

## Fix
Write `text` unconditionally (nullable), regardless of whether tool
execution requests are also present. Read it back the same way.

## ⚠️ Breaking change
This changes the on-wire format for any `AiMessage` that has tool
execution requests — the writer now appends a trailing nullable UTF field
older checkpoints don't have. Reading a pre-fix checkpoint with the fixed
reader throws (EOFException or similar) instead of silently returning
truncated data — by design, so callers can detect it and fall back to the
previous serializer for that checkpoint rather than get corrupted results.

Applications persisting `AgentExecutor` state across this upgrade should
keep a fallback path (old serializer, or catch-and-retry) for checkpoints
written before the upgrade, or expect to start fresh threads. I hit this
exact failure mode upgrading a downstream app and confirmed the fix +
fallback pattern work together in practice.

## Tests
Added `AiMessageTextAndToolExecutionRequestsSerializerTest` and
`AiMessageOnlyToolExecutionRequestsSerializerTest` to `SerializationTest`
(previously no dedicated test existed for `AiMessage` serialization at
all). Full `langchain4j-core` module test suite passes.