### PR TITLE
fix(UserMessageSerializer, ToolExecutionResultMessageSerializer): persist attributes()

### DIFF
--- a/langchain4j/langchain4j-core/src/main/java/org/bsc/langgraph4j/langchain4j/serializer/std/ToolExecutionResultMessageSerializer.java
+++ b/langchain4j/langchain4j-core/src/main/java/org/bsc/langgraph4j/langchain4j/serializer/std/ToolExecutionResultMessageSerializer.java
@@ -7,18 +7,19 @@ import org.bsc.langgraph4j.serializer.std.NullableObjectSerializer;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Map;
 
 import static java.util.Optional.ofNullable;
 
 /**
- * This class is responsible for serializing and deserializing 
- * instances of ToolExecutionResultMessage. It implements the 
+ * This class is responsible for serializing and deserializing
+ * instances of ToolExecutionResultMessage. It implements the
  * Serializer interface to provide custom serialization logic.
  */
 public class ToolExecutionResultMessageSerializer implements NullableObjectSerializer<ToolExecutionResultMessage> {
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ToolExecutionResultMessageSerializer.class);
     /**
-     * Serializes the given ToolExecutionResultMessage object to the 
+     * Serializes the given ToolExecutionResultMessage object to the
      * provided ObjectOutput stream.
      *
      * @param object the ToolExecutionResultMessage object to serialize
@@ -34,16 +35,17 @@ public class ToolExecutionResultMessageSerializer implements NullableObjectSeria
         Serializer.writeUTF( object.toolName(), out );
         Serializer.writeUTF( object.text(), out );
         out.writeBoolean( ofNullable(object.isError()).orElse(false) );
+        out.writeObject( object.attributes() );
     }
 
     /**
-     * Deserializes a ToolExecutionResultMessage object from the 
+     * Deserializes a ToolExecutionResultMessage object from the
      * provided ObjectInput stream.
      *
      * @param in the ObjectInput stream to read the serialized data from
      * @return the deserialized ToolExecutionResultMessage object
      * @throws IOException if an I/O error occurs during deserialization
-     * @throws ClassNotFoundException if the class of a serialized object 
+     * @throws ClassNotFoundException if the class of a serialized object
      *         cannot be found
      */
     @Override
@@ -52,11 +54,14 @@ public class ToolExecutionResultMessageSerializer implements NullableObjectSeria
         String toolName = Serializer.readUTF(in);
         String text = Serializer.readUTF(in);
         Boolean isError = in.readBoolean();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> attributes = (Map<String, Object>) in.readObject();
         return ToolExecutionResultMessage.builder()
                 .id( id )
                 .toolName( toolName )
                 .text( text )
                 .isError( isError )
+                .attributes( attributes )
                 .build();
     }
 }

--- a/langchain4j/langchain4j-core/src/main/java/org/bsc/langgraph4j/langchain4j/serializer/std/UserMessageSerializer.java
+++ b/langchain4j/langchain4j-core/src/main/java/org/bsc/langgraph4j/langchain4j/serializer/std/UserMessageSerializer.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The UserMessageSerializer class implements the NullableObjectSerializer interface for the UserMessage type.
@@ -35,6 +36,7 @@ public class UserMessageSerializer implements NullableObjectSerializer<UserMessa
             out.writeObject( object.contents() );
         }
         writeNullableUTF( object.name(), out);
+        out.writeObject( object.attributes() );
     }
 
     /**
@@ -48,9 +50,10 @@ public class UserMessageSerializer implements NullableObjectSerializer<UserMessa
     @Override
     public UserMessage read(ObjectInput in) throws IOException, ClassNotFoundException {
 
+        UserMessage message;
         try {
             var text = Serializer.readUTF(in);
-            return readNullableUTF(in)
+            message = readNullableUTF(in)
                     .map(name -> UserMessage.from(name, text))
                     .orElseGet(() -> UserMessage.from(text));
         }
@@ -59,10 +62,13 @@ public class UserMessageSerializer implements NullableObjectSerializer<UserMessa
 
             @SuppressWarnings("unchecked")
             var contents = (List<Content>)in.readObject();
-            return readNullableUTF(in)
+            message = readNullableUTF(in)
                     .map( name -> UserMessage.from(name, contents)
                     ).orElseGet(() -> UserMessage.from(contents));
         }
 
+        @SuppressWarnings("unchecked")
+        var attributes = (Map<String, Object>) in.readObject();
+        return message.toBuilder().attributes(attributes).build();
     }
 }

--- a/langchain4j/langchain4j-core/src/test/java/org/bsc/langgraph4j/langchain4j/serializer/std/SerializationTest.java
+++ b/langchain4j/langchain4j-core/src/test/java/org/bsc/langgraph4j/langchain4j/serializer/std/SerializationTest.java
@@ -224,4 +224,65 @@ public class SerializationTest {
         };
 
     }
+
+    @Test
+    public void UserMessageAttributesSerializerTest() throws Exception {
+
+        var userMessage = UserMessage.builder()
+                .name("query")
+                .addContent(new TextContent("query text"))
+                .attributes(Map.of("documentIds", List.of("doc-1", "doc-2")))
+                .build();
+
+        var serializer = new LC4jStateSerializer<>(State::new);
+
+        var state = new State(Map.of(
+                "messages", List.of(userMessage))
+        );
+
+        try (var baos = new ByteArrayOutputStream(); var out = new ObjectOutputStream(baos)) {
+
+            serializer.write(state, out);
+
+            try (var in = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+
+                var newState = serializer.read(in);
+
+                var newUserMessage = (UserMessage) newState.messages().get(0);
+
+                assertEquals(userMessage.attributes(), newUserMessage.attributes());
+            }
+        };
+    }
+
+    @Test
+    public void ToolExecutionResultMessageAttributesSerializerTest() throws Exception {
+
+        var toolResult = ToolExecutionResultMessage.builder()
+                .id("1")
+                .toolName("someTool")
+                .text("result")
+                .attributes(Map.of("someKey", "someValue"))
+                .build();
+
+        var serializer = new LC4jStateSerializer<>(State::new);
+
+        var state = new State(Map.of(
+                "messages", List.of(toolResult))
+        );
+
+        try (var baos = new ByteArrayOutputStream(); var out = new ObjectOutputStream(baos)) {
+
+            serializer.write(state, out);
+
+            try (var in = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+
+                var newState = serializer.read(in);
+
+                var newToolResult = (ToolExecutionResultMessage) newState.messages().get(0);
+
+                assertEquals(toolResult.attributes(), newToolResult.attributes());
+            }
+        };
+    }
 }


### PR DESCRIPTION
## Problem

`UserMessageSerializer` and `ToolExecutionResultMessageSerializer` silently drop the message's `attributes()` map on every checkpoint round-trip: it is never written, so it always comes back **empty** on read, even if it was non-empty going in.

`AiMessageSerializer` already persists `attributes()`. `UserMessage` and `ToolExecutionResultMessage` expose the same `attributes()`/`attribute()` API but lose it entirely.

## Fix

Write `attributes()` unconditionally as a trailing field on both serializers; read it back the same way.

## ⚠️ Breaking change

This changes the on-wire format for `UserMessage` and `ToolExecutionResultMessage`: both writers now append a trailing attributes map that older checkpoints don't have.

Reading a pre-fix checkpoint with this fixed reader throws (`EOFException` or similar) instead of silently returning truncated data — by design, so callers can detect it and fall back to the previous serializer for that checkpoint rather than getting corrupted results.

Applications persisting `AgentExecutor` state across this upgrade should keep a fallback path (old serializer) for checkpoints written before the upgrade, or expect to start fresh threads.

## Tests

Adds to `SerializationTest`:
- `UserMessageAttributesSerializerTest`
- `ToolExecutionResultMessageAttributesSerializerTest`

Both cover the previously-untested attributes round-trip for these two types.
