### PR TITLE
docs(README): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ LangGraph for Java. A library for building stateful, multi-agents applications w
 [![Star History Chart](https://starchart.cc/langgraph4j/langgraph4j.svg)](https://starchart.cc/langgraph4j/langgraph4j)
 -->
 
-<!-- <a href="https://star-history.com/#langgraph4j/langgraph4j&Date">
+<a href="https://star-history.dera.page/#langgraph4j/langgraph4j&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=langgraph4j/langgraph4j&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=langgraph4j/langgraph4j&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=langgraph4j/langgraph4j&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=langgraph4j/langgraph4j&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=langgraph4j/langgraph4j&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=langgraph4j/langgraph4j&type=Date" />
   </picture>
-</a> -->
+</a>
 
 
 # Getting Started


### PR DESCRIPTION
The star history chart in the README is currently broken. The previous service relied on GitHub's stargazer API, which now restricts access, so the chart stopped rendering and was commented out.

This restores the chart using a working provider that requires no API token, so the star history badge is visible again. The MR references commit 7932368 ("chore(README): remove star history section formatting"), which is where the chart was removed.