### PR TITLE
feat(langchain4j-agent): add SkillInjector for tool-triggered dynamic skills

### DIFF
--- a/how-tos/src/site/markdown/index.md
+++ b/how-tos/src/site/markdown/index.md
@@ -6,6 +6,7 @@ They are a collection of how-to(_s_) for LangGraph4j implemented using the [Java
 
 * [Langchain4j Adaptive Rag](adaptiverag.md)
 * [Langchain4j Agent Executor](agentexecutor.md)
+* [SkillInjector (dynamic skills)](skill-injector.md)
 * [Plan-and-Execute](plan-and-execute.md)
 * [Basic Reflection](basic-reflection.md)
 * [How to add persistence to your graph](persistence.md)

--- a/how-tos/src/site/markdown/skill-injector.md
+++ b/how-tos/src/site/markdown/skill-injector.md
@@ -1,0 +1,50 @@
+# SkillInjector (dynamic skills via tool success)
+
+Tool-call–triggered skills for LangChain4j `AgentExecutor`: activate **skill ids** in Graph State after successful tool results; inject skill **bodies** into the next model request via `ConversationContextPolicy` (bodies never enter Graph State).
+
+## Setup
+
+```java
+var injector = SkillInjector.builder()
+    .resolver(new MapToolSkillResolver()
+        .bind("query_logistics", "order-reply"))
+    // pick one body source:
+    .skillsFromClassPath("skills")          // classpath:skills/.../SKILL.md
+    // .skills(ClassPathSkillLoader.loadSkills("skills"))
+    // .skillsFromPath(Path.of("my-skills"))
+    // .skillBody(id -> "...")               // custom
+    .build();
+
+var graph = AgentExecutor.builder()
+    .chatModel(model)
+    .toolsFromObject(businessTools)
+    .skillInjector(injector)   // executeTools hook + conversation policy
+    .build();
+```
+
+Static build-time `.skills(...)` on the builder still works for catalog listing in the system prompt; `SkillInjector` is for **runtime activation** after tools succeed.
+
+## Behaviour
+
+| Step | What happens |
+|------|----------------|
+| Tool succeeds (`ToolExecutionResultMessage` and `isError != true`) | Resolver maps tool → skill ids → merge into `active_skills` via `Command.update` |
+| Tool fails / missing result | **No** activation |
+| Next `CallModel` | Policy prepends skill bodies to the request message view |
+| Graph State `messages` | Unchanged by injection (no skill body persisted) |
+
+## Lifetime
+
+`active_skills` follows Graph State / checkpoint / `threadId`. Same thread without `releaseThread` ≈ Sticky; new thread or `CompileConfig.releaseThread(true)` ≈ Ephemeral.
+
+`AgentExecutor.State.SCHEMA` always includes the optional `active_skills` channel; without `skillInjector`, nothing is activated and ReAct behaviour is unchanged.
+
+## Hooks only
+
+```java
+AgentExecutor.builder()
+    .addCallModelHook(...)
+    .addExecuteToolsHook(injector.executeToolsHook())
+    .conversationContextPolicy(injector.asConversationContextPolicy(existingPolicy))
+    ...
+```

--- a/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/AgentExecutor.java
+++ b/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/AgentExecutor.java
@@ -11,11 +11,15 @@ import org.bsc.langgraph4j.GraphStateException;
 import org.bsc.langgraph4j.StateGraph;
 import org.bsc.langgraph4j.action.*;
 import org.bsc.langgraph4j.agent.Agent;
+import org.bsc.langgraph4j.hook.EdgeHook;
+import org.bsc.langgraph4j.hook.NodeHook;
 import org.bsc.langgraph4j.langchain4j.serializer.jackson.LC4jJacksonStateSerializer;
 import org.bsc.langgraph4j.langchain4j.serializer.std.LC4jStateSerializer;
 import org.bsc.langgraph4j.langchain4j.tool.LC4jToolService;
 import org.bsc.langgraph4j.prebuilt.MessagesState;
 import org.bsc.langgraph4j.serializer.StateSerializer;
+import org.bsc.langgraph4j.state.Channel;
+import org.bsc.langgraph4j.state.Channels;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -35,6 +39,18 @@ public interface AgentExecutor {
     class State extends MessagesState<ChatMessage> {
 
         public static final String FINAL_RESPONSE = "agent_response";
+        public static final String ACTIVE_SKILLS = "active_skills";
+
+        /**
+         * Extends {@link MessagesState#SCHEMA} with a replacing {@code active_skills} channel
+         * (skill activation ids only — bodies stay out of state).
+         */
+        public static final Map<String, Channel<?>> SCHEMA;
+        static {
+            var schema = new java.util.HashMap<String, Channel<?>>(MessagesState.SCHEMA);
+            schema.put(ACTIVE_SKILLS, Channels.base(ArrayList::new));
+            SCHEMA = Map.copyOf(schema);
+        }
 
         /**
          * Constructs a new State with the given initialization data.
@@ -54,6 +70,13 @@ public interface AgentExecutor {
             return value(FINAL_RESPONSE);
         }
 
+        /**
+         * Currently activated skill ids (empty if none).
+         */
+        @SuppressWarnings("unchecked")
+        public List<String> activeSkills() {
+            return this.<List<String>>value(ACTIVE_SKILLS).orElseGet(List::of);
+        }
 
     }
 
@@ -124,6 +147,8 @@ public interface AgentExecutor {
      */
     class Builder extends AgentExecutorBuilder<State,Builder> {
 
+        private final Agent.Builder<ChatMessage, State> agentBuilder = Agent.builder();
+
         /**
          * Sets the tool specification for the graph builder.
          *
@@ -167,6 +192,34 @@ public interface AgentExecutor {
         }
 
         /**
+         * Registers a wrap hook around the {@code agent} (call-model) node.
+         * Aligns with {@link Agent.Builder#addCallModelHook} / Spring {@code ReactAgent}.
+         */
+        public Builder addCallModelHook(NodeHook.WrapCall<State> wrapCall) {
+            agentBuilder.addCallModelHook(wrapCall);
+            return this;
+        }
+
+        /**
+         * Registers a wrap hook around the {@code action} (execute-tools) conditional edge.
+         * Aligns with {@link Agent.Builder#addExecuteToolsHook} / Spring {@code ReactAgent}.
+         */
+        public Builder addExecuteToolsHook(EdgeHook.WrapCall<State> wrapCall) {
+            agentBuilder.addExecuteToolsHook(wrapCall);
+            return this;
+        }
+
+        /**
+         * Wires {@link SkillInjector}: execute-tools activation hook + conversation policy
+         * (composed with any previously set policy).
+         */
+        public Builder skillInjector(SkillInjector injector) {
+            addExecuteToolsHook(injector.executeToolsHook());
+            conversationContextPolicy(injector.asConversationContextPolicy(conversationContextPolicy));
+            return this;
+        }
+
+        /**
          * Builds the state graph.
          *
          * @return the constructed StateGraph
@@ -183,7 +236,7 @@ public interface AgentExecutor {
 
             final LC4jToolService toolService = new LC4jToolService(toolMap());
 
-            return Agent.<ChatMessage,State>builder()
+            return agentBuilder
                     .stateSerializer( ofNullable(stateSerializer).orElseGet(Serializers.JSON::object) )
                     .schema( State.SCHEMA )
                     .callModelAction( new CallModel<>( this ) )

--- a/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/MapToolSkillResolver.java
+++ b/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/MapToolSkillResolver.java
@@ -1,0 +1,30 @@
+package org.bsc.langgraph4j.agentexecutor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Explicit tool → skill id bindings for {@link ToolSkillResolver}.
+ */
+public final class MapToolSkillResolver implements ToolSkillResolver {
+
+    private final Map<String, List<String>> bindings = new LinkedHashMap<>();
+
+    public MapToolSkillResolver bind(String toolName, String skillId) {
+        bindings.computeIfAbsent(toolName, k -> new ArrayList<>()).add(skillId);
+        return this;
+    }
+
+    public MapToolSkillResolver bind(String toolName, List<String> skillIds) {
+        bindings.computeIfAbsent(toolName, k -> new ArrayList<>()).addAll(skillIds);
+        return this;
+    }
+
+    @Override
+    public List<String> resolve(String toolName) {
+        var ids = bindings.get(toolName);
+        return ids == null ? List.of() : List.copyOf(ids);
+    }
+}

--- a/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/SkillInjector.java
+++ b/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/SkillInjector.java
@@ -1,0 +1,189 @@
+package org.bsc.langgraph4j.agentexecutor;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.skills.ClassPathSkillLoader;
+import dev.langchain4j.skills.FileSystemSkillLoader;
+import dev.langchain4j.skills.Skill;
+import org.bsc.langgraph4j.RunnableConfig;
+import org.bsc.langgraph4j.action.Command;
+import org.bsc.langgraph4j.agent.ConversationContextPolicy;
+import org.bsc.langgraph4j.hook.EdgeHook;
+import org.bsc.langgraph4j.prebuilt.MessagesState;
+import org.bsc.langgraph4j.utils.TypeRef;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Tool-call–triggered dynamic skills: activate ids on successful tool results
+ * (via execute-tools edge wrap + {@link Command#update()}), materialize bodies
+ * through {@link ConversationContextPolicy} (never written into Graph State).
+ */
+public final class SkillInjector {
+
+    private static final TypeRef<List<ToolExecutionResultMessage>> TOOL_RESULTS =
+            new TypeRef<>() {};
+
+    private final ToolSkillResolver resolver;
+    private final Function<String, String> skillBody;
+
+    private SkillInjector(ToolSkillResolver resolver, Function<String, String> skillBody) {
+        this.resolver = Objects.requireNonNull(resolver, "resolver");
+        this.skillBody = Objects.requireNonNull(skillBody, "skillBody");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Wrap hook for {@link AgentExecutor.Builder#addExecuteToolsHook}: after tools run,
+     * merge successful tool → skill ids into {@link AgentExecutor.State#ACTIVE_SKILLS}.
+     */
+    public EdgeHook.WrapCall<AgentExecutor.State> executeToolsHook() {
+        return (sourceId, state, config, action) ->
+                action.apply(state, config).thenApply(command -> activate(state, command));
+    }
+
+    /**
+     * Policy that prepends activated skill bodies to the model-bound message view.
+     * Does not mutate graph state.
+     */
+    public ConversationContextPolicy<ChatMessage> asConversationContextPolicy() {
+        return asConversationContextPolicy(null);
+    }
+
+    /**
+     * Decorates an existing policy: filter first, then prepend skill bodies.
+     */
+    public ConversationContextPolicy<ChatMessage> asConversationContextPolicy(
+            ConversationContextPolicy<ChatMessage> existing) {
+        return new ConversationContextPolicy<>() {
+            @Override
+            public <S extends MessagesState<ChatMessage>> List<ChatMessage> filter(
+                    S state, RunnableConfig config) {
+                List<ChatMessage> base = existing != null
+                        ? existing.filter(state, config)
+                        : new ArrayList<>(state.messages());
+                List<String> ids = state instanceof AgentExecutor.State agentState
+                        ? agentState.activeSkills()
+                        : state.<List<String>>value(AgentExecutor.State.ACTIVE_SKILLS).orElseGet(List::of);
+                if (ids.isEmpty()) {
+                    return base;
+                }
+                var view = new ArrayList<ChatMessage>(ids.size() + base.size());
+                for (String id : ids) {
+                    var body = skillBody.apply(id);
+                    if (body != null && !body.isBlank()) {
+                        view.add(SystemMessage.from(body));
+                    }
+                }
+                view.addAll(base);
+                return view;
+            }
+        };
+    }
+
+    Command activate(AgentExecutor.State state, Command command) {
+        var successfulTools = successfulToolNames(command);
+        if (successfulTools.isEmpty()) {
+            return command;
+        }
+        var merged = new LinkedHashSet<>(state.activeSkills());
+        for (String toolName : successfulTools) {
+            merged.addAll(resolver.resolve(toolName));
+        }
+        if (merged.equals(new LinkedHashSet<>(state.activeSkills()))) {
+            return command;
+        }
+        return command.withMergedUpdate(Map.of(
+                AgentExecutor.State.ACTIVE_SKILLS, new ArrayList<>(merged)));
+    }
+
+    static List<String> successfulToolNames(Command command) {
+        var raw = command.update().get("messages");
+        if (raw == null) {
+            return List.of();
+        }
+        var messages = TOOL_RESULTS.cast(raw).orElse(null);
+        if (messages == null) {
+            return List.of();
+        }
+        var names = new ArrayList<String>();
+        for (ToolExecutionResultMessage msg : messages) {
+            if (!Boolean.TRUE.equals(msg.isError())) {
+                names.add(msg.toolName());
+            }
+        }
+        return names;
+    }
+
+    private static Function<String, String> bodyIndexFromSkills(Collection<? extends Skill> skills) {
+        var byName = new LinkedHashMap<String, String>();
+        for (Skill skill : skills) {
+            byName.put(skill.name(), skill.content());
+        }
+        return id -> byName.getOrDefault(id, "");
+    }
+
+    public static final class Builder {
+        private ToolSkillResolver resolver = toolName -> List.of();
+        private Function<String, String> skillBody = id -> "";
+
+        public Builder resolver(ToolSkillResolver resolver) {
+            this.resolver = resolver;
+            return this;
+        }
+
+        /**
+         * Custom body loader by skill id (overrides {@link #skills} if set after).
+         */
+        public Builder skillBody(Function<String, String> skillBody) {
+            this.skillBody = skillBody;
+            return this;
+        }
+
+        /**
+         * Index skill bodies from LC4j {@link Skill}s ({@link Skill#name()} → {@link Skill#content()}).
+         * Compatible with {@link ClassPathSkillLoader} / {@link FileSystemSkillLoader} results.
+         */
+        public Builder skills(Collection<? extends Skill> skills) {
+            this.skillBody = bodyIndexFromSkills(
+                    Objects.requireNonNull(skills, "skills"));
+            return this;
+        }
+
+        public Builder skills(Skill... skills) {
+            return skills(List.of(Objects.requireNonNull(skills, "skills")));
+        }
+
+        /**
+         * Load skills from the classpath (e.g. {@code "skills"} → {@code classpath:skills/.../SKILL.md}).
+         */
+        public Builder skillsFromClassPath(String resourceRoot) {
+            return skills(ClassPathSkillLoader.loadSkills(
+                    Objects.requireNonNull(resourceRoot, "resourceRoot")));
+        }
+
+        /**
+         * Load skills from a filesystem directory.
+         */
+        public Builder skillsFromPath(Path directory) {
+            return skills(FileSystemSkillLoader.loadSkills(
+                    Objects.requireNonNull(directory, "directory")));
+        }
+
+        public SkillInjector build() {
+            return new SkillInjector(resolver, skillBody);
+        }
+    }
+}

--- a/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/ToolSkillResolver.java
+++ b/langchain4j/langchain4j-agent/src/main/java/org/bsc/langgraph4j/agentexecutor/ToolSkillResolver.java
@@ -1,0 +1,16 @@
+package org.bsc.langgraph4j.agentexecutor;
+
+import java.util.List;
+
+/**
+ * Maps a business tool name to zero or more skill ids to activate.
+ */
+@FunctionalInterface
+public interface ToolSkillResolver {
+
+    /**
+     * @param toolName tool that executed successfully
+     * @return skill ids to activate (never {@code null}; empty = none)
+     */
+    List<String> resolve(String toolName);
+}

--- a/langchain4j/langchain4j-agent/src/test/java/org/bsc/langgraph4j/agentexecutor/AgentExecutorHookPassthroughTest.java
+++ b/langchain4j/langchain4j-agent/src/test/java/org/bsc/langgraph4j/agentexecutor/AgentExecutorHookPassthroughTest.java
@@ -1,0 +1,105 @@
+package org.bsc.langgraph4j.agentexecutor;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import org.bsc.langgraph4j.agent.Agent;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Minimal check: AgentExecutor Builder hook passthrough reaches
+ * call-model node wrap and execute-tools edge wrap (same wiring as Agent / Spring ReactAgent).
+ */
+class AgentExecutorHookPassthroughTest {
+
+    static class EchoTools {
+        @Tool("echo input")
+        public String echo(String text) {
+            return "echo:" + text;
+        }
+    }
+
+    static class ScriptedChatModel implements ChatModel {
+        private final AtomicInteger calls = new AtomicInteger();
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            if (calls.getAndIncrement() == 0) {
+                var req = ToolExecutionRequest.builder()
+                        .id("call-1")
+                        .name("echo")
+                        .arguments("{\"arg0\":\"hi\"}")
+                        .build();
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from(req))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("done"))
+                    .finishReason(FinishReason.STOP)
+                    .build();
+        }
+    }
+
+    @Test
+    void callModelAndExecuteToolsWrapHooksAreInvoked() throws Exception {
+        List<String> timeline = new ArrayList<>();
+
+        var app = AgentExecutor.builder()
+                .chatModel(new ScriptedChatModel())
+                .toolsFromObject(new EchoTools())
+                .addCallModelHook((nodeId, state, config, action) -> {
+                    timeline.add("NODE_WRAP:enter:" + nodeId);
+                    return action.apply(state, config).thenApply(result -> {
+                        timeline.add("NODE_WRAP:exit:" + nodeId);
+                        return result;
+                    });
+                })
+                .addExecuteToolsHook((sourceId, state, config, action) -> {
+                    timeline.add("EDGE_WRAP:enter:" + sourceId);
+                    return action.apply(state, config).thenApply(cmd -> {
+                        timeline.add("EDGE_WRAP:exit:" + sourceId);
+                        return cmd;
+                    });
+                })
+                .build()
+                .compile();
+
+        var result = app.invoke(Map.of("messages", UserMessage.from("go"))).orElseThrow();
+
+        assertTrue(result.finalResponse().isPresent());
+        assertEquals("done", result.finalResponse().get());
+
+        System.out.println("=== AgentExecutor hook passthrough timeline ===");
+        for (int i = 0; i < timeline.size(); i++) {
+            System.out.printf("%02d  %s%n", i, timeline.get(i));
+        }
+        System.out.println("===============================================");
+
+        // ReAct: agent → action(tools) → agent → action(no tools → END)
+        assertEquals(List.of(
+                "NODE_WRAP:enter:" + Agent.AGENT_LABEL,
+                "NODE_WRAP:exit:" + Agent.AGENT_LABEL,
+                "EDGE_WRAP:enter:" + Agent.ACTION_LABEL,
+                "EDGE_WRAP:exit:" + Agent.ACTION_LABEL,
+                "NODE_WRAP:enter:" + Agent.AGENT_LABEL,
+                "NODE_WRAP:exit:" + Agent.AGENT_LABEL,
+                "EDGE_WRAP:enter:" + Agent.ACTION_LABEL,
+                "EDGE_WRAP:exit:" + Agent.ACTION_LABEL
+        ), timeline);
+    }
+}

--- a/langchain4j/langchain4j-agent/src/test/java/org/bsc/langgraph4j/agentexecutor/SkillInjectorActivationTest.java
+++ b/langchain4j/langchain4j-agent/src/test/java/org/bsc/langgraph4j/agentexecutor/SkillInjectorActivationTest.java
@@ -1,0 +1,124 @@
+package org.bsc.langgraph4j.agentexecutor;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PR1.2 — After successful tool execution, skill ids land in Graph State;
+ * next CallModel request receives skill body via Policy; state messages stay clean.
+ */
+class SkillInjectorActivationTest {
+
+    private static final String SKILL_MARKER = "DYNAMIC_SKILL_BODY::order-reply";
+
+    static class LogisticsTools {
+        @Tool("query order logistics")
+        public String query_logistics(String orderId) {
+            return "shipped:" + orderId;
+        }
+    }
+
+    static class ScriptedChatModel implements ChatModel {
+        private final AtomicInteger calls = new AtomicInteger();
+        final List<ChatRequest> requests = new ArrayList<>();
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            requests.add(chatRequest);
+            if (calls.getAndIncrement() == 0) {
+                var req = ToolExecutionRequest.builder()
+                        .id("call-1")
+                        .name("query_logistics")
+                        .arguments("{\"arg0\":\"O-1\"}")
+                        .build();
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from(req))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("物流已发出"))
+                    .finishReason(FinishReason.STOP)
+                    .build();
+        }
+    }
+
+    @Test
+    void successfulToolActivatesSkillIdAndPolicyInjectsBodyOnNextModelCall() throws Exception {
+        var chatModel = new ScriptedChatModel();
+        var injector = SkillInjector.builder()
+                .resolver(new MapToolSkillResolver().bind("query_logistics", "order-reply"))
+                .skillBody(id -> SKILL_MARKER)
+                .build();
+
+        var app = AgentExecutor.builder()
+                .chatModel(chatModel)
+                .toolsFromObject(new LogisticsTools())
+                .skillInjector(injector)
+                .build()
+                .compile();
+
+        var result = app.invoke(Map.of("messages", UserMessage.from("查物流"))).orElseThrow();
+
+        assertEquals(List.of("order-reply"), result.activeSkills());
+        assertEquals(2, chatModel.requests.size());
+
+        // First model call: no activation yet
+        assertFalse(chatModel.requests.get(0).messages().stream().anyMatch(m ->
+                m instanceof SystemMessage sm && sm.text().contains(SKILL_MARKER)));
+
+        // Second model call: Policy injected skill body
+        assertTrue(chatModel.requests.get(1).messages().stream().anyMatch(m ->
+                m instanceof SystemMessage sm && sm.text().contains(SKILL_MARKER)));
+
+        // Graph messages must not contain skill body
+        assertFalse(result.messages().stream().anyMatch(m ->
+                m instanceof SystemMessage sm && sm.text().contains(SKILL_MARKER)));
+
+        System.out.println("PR1.2 OK: active_skills=" + result.activeSkills()
+                + " ; 2nd request has skill body; state messages clean");
+    }
+
+    @Test
+    void skillsFromClassPathProvideRealSkillBody() throws Exception {
+        var chatModel = new ScriptedChatModel();
+        // maps logistics tool → existing test resource skill "agent-commit"
+        var injector = SkillInjector.builder()
+                .resolver(new MapToolSkillResolver().bind("query_logistics", "agent-commit"))
+                .skillsFromClassPath("skills")
+                .build();
+
+        var app = AgentExecutor.builder()
+                .chatModel(chatModel)
+                .toolsFromObject(new LogisticsTools())
+                .skillInjector(injector)
+                .build()
+                .compile();
+
+        var result = app.invoke(Map.of("messages", UserMessage.from("查物流"))).orElseThrow();
+
+        assertEquals(List.of("agent-commit"), result.activeSkills());
+        assertTrue(chatModel.requests.get(1).messages().stream().anyMatch(m ->
+                m instanceof SystemMessage sm && sm.text().contains("Conventional commit")),
+                "2nd request should contain body from classpath skills/agent-commit");
+        assertFalse(result.messages().stream().anyMatch(m ->
+                m instanceof SystemMessage sm && sm.text().contains("Conventional commit")));
+    }
+}

--- a/langchain4j/langchain4j-agent/src/test/java/org/bsc/langgraph4j/agentexecutor/SkillInjectorSuccessGateTest.java
+++ b/langchain4j/langchain4j-agent/src/test/java/org/bsc/langgraph4j/agentexecutor/SkillInjectorSuccessGateTest.java
@@ -1,0 +1,126 @@
+package org.bsc.langgraph4j.agentexecutor;
+
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import org.bsc.langgraph4j.action.Command;
+import org.bsc.langgraph4j.agent.Agent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Hard rules: only successful tool results activate skills.
+ */
+class SkillInjectorSuccessGateTest {
+
+    @Test
+    void errorToolResultDoesNotActivate() {
+        var injector = SkillInjector.builder()
+                .resolver(new MapToolSkillResolver().bind("query_logistics", "order-reply"))
+                .skillBody(id -> "BODY")
+                .build();
+
+        var state = new AgentExecutor.State(Map.of());
+        var command = new Command(Agent.AGENT_LABEL, Map.of(
+                "messages", List.of(
+                        ToolExecutionResultMessage.builder()
+                                .id("1")
+                                .toolName("query_logistics")
+                                .text("boom")
+                                .isError(true)
+                                .build()
+                )
+        ));
+
+        var next = injector.activate(state, command);
+        assertTrue(next.update().get(AgentExecutor.State.ACTIVE_SKILLS) == null
+                        || ((List<?>) next.update().getOrDefault(AgentExecutor.State.ACTIVE_SKILLS, List.of())).isEmpty(),
+                "isError=true must not write active_skills");
+        assertEquals(command.gotoNode(), next.gotoNode());
+    }
+
+    @Test
+    void missingMessagesUpdateDoesNotActivate() {
+        var injector = SkillInjector.builder()
+                .resolver(new MapToolSkillResolver().bind("query_logistics", "order-reply"))
+                .build();
+
+        var state = new AgentExecutor.State(Map.of());
+        var command = new Command(Agent.END_LABEL, Map.of());
+
+        var next = injector.activate(state, command);
+        assertTrue(next.update().isEmpty() || next.update().get(AgentExecutor.State.ACTIVE_SKILLS) == null);
+    }
+
+    @Test
+    void successfulToolResultActivates() {
+        var injector = SkillInjector.builder()
+                .resolver(new MapToolSkillResolver().bind("query_logistics", "order-reply"))
+                .build();
+
+        var state = new AgentExecutor.State(Map.of());
+        var command = new Command(Agent.AGENT_LABEL, Map.of(
+                "messages", List.of(
+                        ToolExecutionResultMessage.builder()
+                                .id("1")
+                                .toolName("query_logistics")
+                                .text("ok")
+                                .isError(false)
+                                .build()
+                )
+        ));
+
+        var next = injector.activate(state, command);
+        assertEquals(List.of("order-reply"), next.update().get(AgentExecutor.State.ACTIVE_SKILLS));
+    }
+
+    @Test
+    void mixedBatchActivatesOnlySuccessfulTools() {
+        var injector = SkillInjector.builder()
+                .resolver(new MapToolSkillResolver()
+                        .bind("ok_tool", "skill-ok")
+                        .bind("fail_tool", "skill-fail"))
+                .build();
+
+        var state = new AgentExecutor.State(Map.of());
+        var command = new Command(Agent.AGENT_LABEL, Map.of(
+                "messages", List.of(
+                        ToolExecutionResultMessage.builder()
+                                .id("a").toolName("ok_tool").text("ok").isError(false).build(),
+                        ToolExecutionResultMessage.builder()
+                                .id("b").toolName("fail_tool").text("no").isError(true).build()
+                )
+        ));
+
+        var next = injector.activate(state, command);
+        assertEquals(List.of("skill-ok"), next.update().get(AgentExecutor.State.ACTIVE_SKILLS));
+    }
+
+    @Test
+    void reactivatingSameSkillDoesNotDuplicate() {
+        var injector = SkillInjector.builder()
+                .resolver(new MapToolSkillResolver().bind("query_logistics", "order-reply"))
+                .build();
+
+        var state = new AgentExecutor.State(Map.of(
+                AgentExecutor.State.ACTIVE_SKILLS, List.of("order-reply")));
+        var command = new Command(Agent.AGENT_LABEL, Map.of(
+                "messages", List.of(
+                        ToolExecutionResultMessage.builder()
+                                .id("2")
+                                .toolName("query_logistics")
+                                .text("ok-again")
+                                .isError(false)
+                                .build()
+                )
+        ));
+
+        var next = injector.activate(state, command);
+        // set merge: no-op write when membership unchanged
+        assertTrue(next.update().get(AgentExecutor.State.ACTIVE_SKILLS) == null);
+        assertEquals(List.of("order-reply"), state.activeSkills());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `SkillInjector`, an opt-in mechanism for **tool-call–triggered** (event-driven) dynamic skills in `langchain4j-agent`. It activates skill *ids* on the execute-tools path only from **successful** tool results, and materializes skill *bodies* into the model request through `ConversationContextPolicy` — never into graph state.

## Motivation

Build-time static `skills()` loads every skill description into the system prompt up front. In agent flows where the *result* of a tool call deterministically implies a follow-up skill (e.g. a logistics tool succeeding → load the "order reply" skill), that skill should be loaded *after* the tool runs, by code — not decided by the model. This keeps prompt size bounded and behavior predictable.

## How it works

```
ToolSkillResolver (explicit tool → skill ids)
        │
        ▼
execute-tools path (EdgeHook wrap; !isError)
        │   only successful tools → Command.update → state.active_skills (ids)
        ▼
callModel
        │   ConversationContextPolicy.filter(state, config)
        │   materialize bodies from ids → messages view (copy)
        ▼
ChatRequest (contains skill body; graph state has no body)
```

- `SkillInjector` wires an execute-tools activation hook + a `ConversationContextPolicy`.
- `ToolSkillResolver` / `MapToolSkillResolver` provide the explicit tool→skill mapping.
- `AgentExecutor.Builder` gains `addCallModelHook` / `addExecuteToolsHook` (aligned with `Agent.Builder` / Spring `ReactAgent`) and a convenience `skillInjector(...)`.

## Usage

```java
var injector = SkillInjector.builder()
    .skills(ClassPathSkillLoader.loadSkills("skills"))
    .resolver(new MapToolSkillResolver()
        .bind("query_logistics", "order-reply"))
    .build();

AgentExecutor.builder()
    .chatModel(model)
    .toolsFromObject(tools)
    .skillInjector(injector)
    .build();
```

## Semantics (important)

- **Default behavior unchanged** — without `skillInjector(...)`, ReAct behavior is identical to before.
- **State schema** — `AgentExecutor.State.SCHEMA` gains an optional `active_skills` channel (a replacing `Channels.base`), holding activation *ids* only; skill *bodies* never enter graph state. This keeps activation lifetime tied to checkpoint/`threadId` naturally.
- **Activation lifetime** — ids follow checkpoint/threadId/`releaseThread`. Ephemeral use = fresh `threadId` or `releaseThread(true)`; same thread without release = sticky. This is not an implicit invoke-scoped container.
- **Success gate** — activation happens only when a tool result message exists and `!isError`; requested-but-missing or `isError=true` results do not activate.

## Included / not included

Included: `SkillInjector`, `ToolSkillResolver` / `MapToolSkillResolver`, hook passthrough, activation + success-gate tests, how-to doc.

Not included (planned follow-ups): sticky semantics productization / unload API, and optional dynamic `ToolProvider`. Exploration spike tests were kept out of this PR.

## Notes

This implements the "backward" skill-injection slice we discussed earlier — the
event-driven half, where a skill is loaded *after* a tool runs, decided by code
rather than the model. It's my first contribution to langgraph4j, so feedback on
API shape and naming is very welcome, and I look forward to your guidance.
(Related discussion: https://github.com/langgraph4j/langgraph4j/discussions/435)