### PR TITLE
docs(how-tos): add prompt chaining tutorial

### DIFF
--- a/how-tos/agentic-rag.ipynb
+++ b/how-tos/agentic-rag.ipynb
@@ -564,7 +564,7 @@
    "name": "java",
    "nbconvert_exporter": "script",
    "pygments_lexer": "java",
-   "version": "22.0.2+9-70"
+   "version": "21.0.4+7-LTS"
   }
  },
  "nbformat": 4,

--- a/how-tos/prompt-chaining.ipynb
+++ b/how-tos/prompt-chaining.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "81dbf45a",
+   "metadata": {},
+   "source": [
+    "# Prompt chaining\n",
+    "\n",
+    "Original tutorial: [Prompt chaining](https://docs.langchain.com/oss/python/langgraph/workflows-agents#prompt-chaining).\n",
+    "\n",
+    "Prompt chaining runs a sequence of LLM calls where each step uses the result of the previous step. This workflow generates a joke, checks whether it has a punchline, and only improves it when needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e84026d",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Set `OPENAI_API_KEY` before running the model calls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c5df9927",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var userHomeDir = System.getProperty(\"user.home\");\n",
+    "var localRepoUrl = \"file://\" + userHomeDir + \"/.m2/repository/\";\n",
+    "var langchain4jVersion = \"1.19.0\";\n",
+    "var langgraph4jVersion = \"1.8.25\";"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d5fed154",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0mRepository \u001b[1m\u001b[32mlocal\u001b[0m url: \u001b[1m\u001b[32mfile:///Users/leonid/.m2/repository/\u001b[0m added.\n",
+      "\u001b[0mAdding dependency \u001b[0m\u001b[1m\u001b[32morg.bsc.langgraph4j:langgraph4j-core:1.8.25\n",
+      "\u001b[0mAdding dependency \u001b[0m\u001b[1m\u001b[32mdev.langchain4j:langchain4j-open-ai:1.19.0\n",
+      "\u001b[0mSolving dependencies\n",
+      "Resolved artifacts count: 12\n",
+      "\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/org/bsc/langgraph4j/langgraph4j-core/1.8.25/langgraph4j-core-1.8.25.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/org/bsc/async/async-generator/4.3.1/async-generator-4.3.1.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/dev/langchain4j/langchain4j-open-ai/1.19.0/langchain4j-open-ai-1.19.0.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/dev/langchain4j/langchain4j-core/1.19.0/langchain4j-core-1.19.0.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/dev/langchain4j/langchain4j-http-client/1.19.0/langchain4j-http-client-1.19.0.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/dev/langchain4j/langchain4j-http-client-jdk/1.19.0/langchain4j-http-client-jdk-1.19.0.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/com/fasterxml/jackson/core/jackson-annotations/2.22/jackson-annotations-2.22.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/com/fasterxml/jackson/core/jackson-core/2.22.1/jackson-core-2.22.1.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/com/fasterxml/jackson/core/jackson-databind/2.22.1/jackson-databind-2.22.1.jar\u001b[0m\n",
+      "\u001b[0m\u001b[0mAdd to classpath: \u001b[32m/Users/leonid/Library/Jupyter/kernels/rapaio-jupyter-kernel/mima_cache/com/knuddels/jtokkit/1.1.0/jtokkit-1.1.0.jar\u001b[0m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "%dependency /add-repo local \\{localRepoUrl} release|never snapshot|always\n",
+    "%dependency /add org.bsc.langgraph4j:langgraph4j-core:\\{langgraph4jVersion}\n",
+    "%dependency /add dev.langchain4j:langchain4j-open-ai:\\{langchain4jVersion}\n",
+    "%dependency /resolve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2669b048",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dev.langchain4j.model.openai.OpenAiChatModel;\n",
+    "\n",
+    "import java.util.Objects;\n",
+    "\n",
+    "var apiKey = Objects.requireNonNull(\n",
+    "        System.getenv(\"OPENAI_API_KEY\"),\n",
+    "        \"Set OPENAI_API_KEY before running this notebook.\"\n",
+    ");\n",
+    "\n",
+    "var model = OpenAiChatModel.builder()\n",
+    "        .apiKey(apiKey)\n",
+    "        .modelName(\"gpt-4o-mini\")\n",
+    "        .temperature(0.0)\n",
+    "        .build();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6868732",
+   "metadata": {},
+   "source": [
+    "## Define the state\n",
+    "\n",
+    "The state keeps the topic and each version of the joke. Each node updates only the field it produces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "aed59c1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import org.bsc.langgraph4j.state.AgentState;\n",
+    "import org.bsc.langgraph4j.state.Channel;\n",
+    "import org.bsc.langgraph4j.state.Channels;\n",
+    "\n",
+    "import java.util.Map;\n",
+    "\n",
+    "class JokeState extends AgentState {\n",
+    "    static final String TOPIC = \"topic\";\n",
+    "    static final String JOKE = \"joke\";\n",
+    "    static final String IMPROVED_JOKE = \"improved_joke\";\n",
+    "    static final String FINAL_JOKE = \"final_joke\";\n",
+    "\n",
+    "    static final Map<String, Channel<?>> SCHEMA = Map.of(\n",
+    "            TOPIC, Channels.base(() -> \"\"),\n",
+    "            JOKE, Channels.base(() -> \"\"),\n",
+    "            IMPROVED_JOKE, Channels.base(() -> \"\"),\n",
+    "            FINAL_JOKE, Channels.base(() -> \"\")\n",
+    "    );\n",
+    "\n",
+    "    JokeState(Map<String, Object> initData) {\n",
+    "        super(initData);\n",
+    "    }\n",
+    "\n",
+    "    String topic() { return this.<String>value(TOPIC).orElse(\"\"); }\n",
+    "    String joke() { return this.<String>value(JOKE).orElse(\"\"); }\n",
+    "    String improvedJoke() { return this.<String>value(IMPROVED_JOKE).orElse(\"\"); }\n",
+    "    String finalJoke() { return this.<String>value(FINAL_JOKE).orElse(\"\"); }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2add92be",
+   "metadata": {},
+   "source": [
+    "## Define the nodes and routing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c760d1d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dev.langchain4j.data.message.UserMessage;\n",
+    "import org.bsc.langgraph4j.action.EdgeAction;\n",
+    "import org.bsc.langgraph4j.action.NodeAction;\n",
+    "\n",
+    "NodeAction<JokeState> generateJoke = state -> {\n",
+    "    var response = model.chat(UserMessage.from(\"Write a short joke about \" + state.topic()));\n",
+    "    return Map.of(JokeState.JOKE, response.aiMessage().text());\n",
+    "};\n",
+    "\n",
+    "EdgeAction<JokeState> checkPunchline = state ->\n",
+    "        state.joke().contains(\"?\") || state.joke().contains(\"!\") ? \"Pass\" : \"Fail\";\n",
+    "\n",
+    "NodeAction<JokeState> improveJoke = state -> {\n",
+    "    var response = model.chat(UserMessage.from(\"Make this joke funnier by adding wordplay: \" + state.joke()));\n",
+    "    return Map.of(JokeState.IMPROVED_JOKE, response.aiMessage().text());\n",
+    "};\n",
+    "\n",
+    "NodeAction<JokeState> polishJoke = state -> {\n",
+    "    var response = model.chat(UserMessage.from(\"Add a surprising twist to this joke: \" + state.improvedJoke()));\n",
+    "    return Map.of(JokeState.FINAL_JOKE, response.aiMessage().text());\n",
+    "};"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c6553fd",
+   "metadata": {},
+   "source": [
+    "## Build and run the workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "54b512e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial joke:\n",
+      "Why was the cat sitting on the computer?\n",
+      "\n",
+      "Because it wanted to keep an eye on the mouse!\n",
+      "\n",
+      "Final joke:\n",
+      "Why was the cat sitting on the computer?\n",
+      "\n",
+      "Because it wanted to keep an eye on the mouse!\n"
+     ]
+    }
+   ],
+   "source": [
+    "import org.bsc.langgraph4j.StateGraph;\n",
+    "\n",
+    "import static org.bsc.langgraph4j.StateGraph.END;\n",
+    "import static org.bsc.langgraph4j.StateGraph.START;\n",
+    "import static org.bsc.langgraph4j.action.AsyncEdgeAction.edge_async;\n",
+    "import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;\n",
+    "\n",
+    "var workflow = new StateGraph<>(JokeState.SCHEMA, JokeState::new)\n",
+    "        .addNode(\"generate_joke\", node_async(generateJoke))\n",
+    "        .addNode(\"improve_joke\", node_async(improveJoke))\n",
+    "        .addNode(\"polish_joke\", node_async(polishJoke))\n",
+    "        .addEdge(START, \"generate_joke\")\n",
+    "        .addConditionalEdges(\"generate_joke\", edge_async(checkPunchline), Map.of(\n",
+    "                \"Pass\", END,\n",
+    "                \"Fail\", \"improve_joke\"\n",
+    "        ))\n",
+    "        .addEdge(\"improve_joke\", \"polish_joke\")\n",
+    "        .addEdge(\"polish_joke\", END);\n",
+    "\n",
+    "var chain = workflow.compile();\n",
+    "\n",
+    "var result = chain.invoke(Map.of(JokeState.TOPIC, \"cats\"))\n",
+    "        .orElseThrow();\n",
+    "\n",
+    "System.out.println(\"Initial joke:\\n\" + result.joke());\n",
+    "if (result.improvedJoke().isBlank()) {\n",
+    "    System.out.println(\"\\nFinal joke:\\n\" + result.joke());\n",
+    "} else {\n",
+    "    System.out.println(\"\\nImproved joke:\\n\" + result.improvedJoke());\n",
+    "    System.out.println(\"\\nFinal joke:\\n\" + result.finalJoke());\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee2cadcc-e447-49d5-af07-42a1f253a732",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Java (rjk 3.0.4)",
+   "language": "java",
+   "name": "rapaio-jupyter-kernel"
+  },
+  "language_info": {
+   "codemirror_mode": "java",
+   "file_extension": ".jshell",
+   "mimetype": "text/x-java-source",
+   "name": "java",
+   "nbconvert_exporter": "script",
+   "pygments_lexer": "java",
+   "version": "21.0.4+7-LTS"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/how-tos/src/site/markdown/index.md
+++ b/how-tos/src/site/markdown/index.md
@@ -9,6 +9,7 @@ They are a collection of how-to(_s_) for LangGraph4j implemented using the [Java
 * [SkillInjector (dynamic skills)](skill-injector.md)
 * [Plan-and-Execute](plan-and-execute.md)
 * [Basic Reflection](basic-reflection.md)
+* [Prompt chaining](prompt-chaining.md)
 * [How to add persistence to your graph](persistence.md)
 * [How to view and update past graph state](time-travel.md)
 * [Wait for user input](wait-user-input.md)

--- a/how-tos/src/site/markdown/prompt-chaining.md
+++ b/how-tos/src/site/markdown/prompt-chaining.md
@@ -1,0 +1,154 @@
+# Prompt chaining
+
+Original tutorial: [Prompt chaining](https://docs.langchain.com/oss/python/langgraph/workflows-agents#prompt-chaining).
+
+Prompt chaining runs a sequence of LLM calls where each step uses the result of the previous step. This workflow generates a joke, checks whether it has a punchline, and only improves it when needed.
+
+## Setup
+
+Set `OPENAI_API_KEY` before running the model calls.
+
+```java
+var userHomeDir = System.getProperty("user.home");
+var localRepoUrl = "file://" + userHomeDir + "/.m2/repository/";
+var langchain4jVersion = "1.19.0";
+var langgraph4jVersion = "1.8.25";
+```
+
+```java
+%dependency /add-repo local \{localRepoUrl} release|never snapshot|always
+%dependency /add org.bsc.langgraph4j:langgraph4j-core:\{langgraph4jVersion}
+%dependency /add dev.langchain4j:langchain4j-open-ai:\{langchain4jVersion}
+%dependency /resolve
+```
+
+```java
+import dev.langchain4j.model.openai.OpenAiChatModel;
+
+import java.util.Objects;
+
+var apiKey = Objects.requireNonNull(
+        System.getenv("OPENAI_API_KEY"),
+        "Set OPENAI_API_KEY before running this notebook."
+);
+
+var model = OpenAiChatModel.builder()
+        .apiKey(apiKey)
+        .modelName("gpt-4o-mini")
+        .temperature(0.0)
+        .build();
+```
+
+## Define the state
+
+The state keeps the topic and each version of the joke. Each node updates only the field it produces.
+
+```java
+import org.bsc.langgraph4j.state.AgentState;
+import org.bsc.langgraph4j.state.Channel;
+import org.bsc.langgraph4j.state.Channels;
+
+import java.util.Map;
+
+class JokeState extends AgentState {
+    static final String TOPIC = "topic";
+    static final String JOKE = "joke";
+    static final String IMPROVED_JOKE = "improved_joke";
+    static final String FINAL_JOKE = "final_joke";
+
+    static final Map<String, Channel<?>> SCHEMA = Map.of(
+            TOPIC, Channels.base(() -> ""),
+            JOKE, Channels.base(() -> ""),
+            IMPROVED_JOKE, Channels.base(() -> ""),
+            FINAL_JOKE, Channels.base(() -> "")
+    );
+
+    JokeState(Map<String, Object> initData) {
+        super(initData);
+    }
+
+    String topic() {
+        return this.<String>value(TOPIC).orElse("");
+    }
+
+    String joke() {
+        return this.<String>value(JOKE).orElse("");
+    }
+
+    String improvedJoke() {
+        return this.<String>value(IMPROVED_JOKE).orElse("");
+    }
+
+    String finalJoke() {
+        return this.<String>value(FINAL_JOKE).orElse("");
+    }
+}
+```
+
+## Define the nodes and routing
+
+```java
+import dev.langchain4j.data.message.UserMessage;
+import org.bsc.langgraph4j.action.EdgeAction;
+import org.bsc.langgraph4j.action.NodeAction;
+
+NodeAction<JokeState> generateJoke = state -> {
+    var response = model.chat(UserMessage.from(
+            "Write a short joke about " + state.topic()
+    ));
+    return Map.of(JokeState.JOKE, response.aiMessage().text());
+};
+
+EdgeAction<JokeState> checkPunchline = state ->
+        state.joke().contains("?") || state.joke().contains("!") ? "Pass" : "Fail";
+
+NodeAction<JokeState> improveJoke = state -> {
+    var response = model.chat(UserMessage.from(
+            "Make this joke funnier by adding wordplay: " + state.joke()
+    ));
+    return Map.of(JokeState.IMPROVED_JOKE, response.aiMessage().text());
+};
+
+NodeAction<JokeState> polishJoke = state -> {
+    var response = model.chat(UserMessage.from(
+            "Add a surprising twist to this joke: " + state.improvedJoke()
+    ));
+    return Map.of(JokeState.FINAL_JOKE, response.aiMessage().text());
+};
+```
+
+## Build and run the workflow
+
+```java
+import org.bsc.langgraph4j.StateGraph;
+
+import static org.bsc.langgraph4j.StateGraph.END;
+import static org.bsc.langgraph4j.StateGraph.START;
+import static org.bsc.langgraph4j.action.AsyncEdgeAction.edge_async;
+import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;
+
+var workflow = new StateGraph<>(JokeState.SCHEMA, JokeState::new)
+        .addNode("generate_joke", node_async(generateJoke))
+        .addNode("improve_joke", node_async(improveJoke))
+        .addNode("polish_joke", node_async(polishJoke))
+        .addEdge(START, "generate_joke")
+        .addConditionalEdges("generate_joke", edge_async(checkPunchline), Map.of(
+                "Pass", END,
+                "Fail", "improve_joke"
+        ))
+        .addEdge("improve_joke", "polish_joke")
+        .addEdge("polish_joke", END);
+
+var chain = workflow.compile();
+
+var result = chain.invoke(Map.of(JokeState.TOPIC, "cats"))
+        .orElseThrow();
+
+System.out.println("Initial joke:\n" + result.joke());
+if (result.improvedJoke().isBlank()) {
+    System.out.println("\nFinal joke:\n" + result.joke());
+} else {
+    System.out.println("\nImproved joke:\n" + result.improvedJoke());
+    System.out.println("\nFinal joke:\n" + result.finalJoke());
+}
+```

--- a/how-tos/src/test/java/org/bsc/langgraph4j/PromptChainingStubTest.java
+++ b/how-tos/src/test/java/org/bsc/langgraph4j/PromptChainingStubTest.java
@@ -1,0 +1,109 @@
+package org.bsc.langgraph4j;
+
+import org.bsc.langgraph4j.action.EdgeAction;
+import org.bsc.langgraph4j.action.NodeAction;
+import org.bsc.langgraph4j.state.AgentState;
+import org.bsc.langgraph4j.state.Channel;
+import org.bsc.langgraph4j.state.Channels;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.bsc.langgraph4j.StateGraph.END;
+import static org.bsc.langgraph4j.StateGraph.START;
+import static org.bsc.langgraph4j.action.AsyncEdgeAction.edge_async;
+import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Deterministic coverage for the Prompt Chaining how-to.
+ */
+public class PromptChainingStubTest {
+
+    static class JokeState extends AgentState {
+        static final String TOPIC = "topic";
+        static final String JOKE = "joke";
+        static final String IMPROVED_JOKE = "improved_joke";
+        static final String FINAL_JOKE = "final_joke";
+
+        static final Map<String, Channel<?>> SCHEMA = Map.of(
+                TOPIC, Channels.base(() -> ""),
+                JOKE, Channels.base(() -> ""),
+                IMPROVED_JOKE, Channels.base(() -> ""),
+                FINAL_JOKE, Channels.base(() -> "")
+        );
+
+        JokeState(Map<String, Object> initData) {
+            super(initData);
+        }
+
+        String topic() {
+            return this.<String>value(TOPIC).orElse("");
+        }
+
+        String joke() {
+            return this.<String>value(JOKE).orElse("");
+        }
+
+        String improvedJoke() {
+            return this.<String>value(IMPROVED_JOKE).orElse("");
+        }
+
+        String finalJoke() {
+            return this.<String>value(FINAL_JOKE).orElse("");
+        }
+    }
+
+    @Test
+    void promptChainStopsWhenTheInitialJokeHasAPunchline() throws Exception {
+        var result = workflow().invoke(Map.of(JokeState.TOPIC, "pass"))
+                .orElseThrow();
+
+        assertTrue(result.joke().contains("?"));
+        assertEquals("", result.improvedJoke());
+        assertEquals("", result.finalJoke());
+    }
+
+    @Test
+    void promptChainImprovesAndPolishesJokesWithoutAPunchline() throws Exception {
+        var result = workflow().invoke(Map.of(JokeState.TOPIC, "fail"))
+                .orElseThrow();
+
+        assertEquals("Cats write code", result.joke());
+        assertEquals("Cats write code with purr-fect formatting", result.improvedJoke());
+        assertEquals("Cats write code with purr-fect formatting!", result.finalJoke());
+    }
+
+    private CompiledGraph<JokeState> workflow() throws GraphStateException {
+        NodeAction<JokeState> generateJoke = state -> Map.of(
+                JokeState.JOKE,
+                state.topic().equals("pass")
+                        ? "Why do cats make great programmers? They always avoid cat-astrophic bugs!"
+                        : "Cats write code"
+        );
+        EdgeAction<JokeState> checkPunchline = state ->
+                state.joke().contains("?") || state.joke().contains("!") ? "Pass" : "Fail";
+        NodeAction<JokeState> improveJoke = state -> Map.of(
+                JokeState.IMPROVED_JOKE,
+                state.joke() + " with purr-fect formatting"
+        );
+        NodeAction<JokeState> polishJoke = state -> Map.of(
+                JokeState.FINAL_JOKE,
+                state.improvedJoke() + "!"
+        );
+
+        return new StateGraph<>(JokeState.SCHEMA, JokeState::new)
+                .addNode("generate_joke", node_async(generateJoke))
+                .addNode("improve_joke", node_async(improveJoke))
+                .addNode("polish_joke", node_async(polishJoke))
+                .addEdge(START, "generate_joke")
+                .addConditionalEdges("generate_joke", edge_async(checkPunchline), Map.of(
+                        "Pass", END,
+                        "Fail", "improve_joke"
+                ))
+                .addEdge("improve_joke", "polish_joke")
+                .addEdge("polish_joke", END)
+                .compile();
+    }
+}


### PR DESCRIPTION
- add a runnable [Prompt Chaining](https://docs.langchain.com/oss/python/langgraph/workflows-agents#prompt-chaining) how-to as a Java notebook and Markdown page
- implement the canonical LangGraph4j `StateGraph` workflow with a conditional punchline branch
- add deterministic tests for both the early-exit and improvement paths
- add the tutorial to the how-to index