### PR TITLE
feat(core): add configurable node retry policy

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -27,16 +28,21 @@ public final class RetryPolicy {
 
     private static final Duration DEFAULT_RETRY_DELAY = Duration.ofMillis(500);
     private static final double DEFAULT_BACKOFF_FACTOR = 2.0;
+    private static final Duration DEFAULT_MAX_INTERVAL = Duration.ofSeconds(128);
 
     private final int maxAttempts;
     private final Duration retryDelay;
     private final double backoffFactor;
+    private final Duration maxInterval;
+    private final boolean jitter;
     private final Predicate<Throwable> retryOn;
 
     private RetryPolicy(Builder builder) {
         this.maxAttempts = builder.maxAttempts;
         this.retryDelay = builder.retryDelay;
         this.backoffFactor = builder.backoffFactor;
+        this.maxInterval = builder.maxInterval;
+        this.jitter = builder.jitter;
         this.retryOn = builder.retryOn;
     }
 
@@ -85,11 +91,21 @@ public final class RetryPolicy {
     }
 
     private CompletableFuture<Void> delay(int attempt) {
-        var delayNanos = Math.min(
-                retryDelay.toNanos() * Math.pow(backoffFactor, attempt - 1.0),
-                Long.MAX_VALUE);
         return runAsync(() -> {
-        }, delayedExecutor((long) delayNanos, NANOSECONDS));
+        }, delayedExecutor(delayNanos(attempt), NANOSECONDS));
+    }
+
+    long delayNanos(int attempt) {
+        var baseDelayNanos = Math.min(
+                retryDelay.toNanos() * Math.pow(backoffFactor, attempt - 1.0),
+                maxInterval.toNanos());
+
+        var jitterDelay = 0.0;
+        if (jitter && baseDelayNanos > 0) {
+            jitterDelay = ThreadLocalRandom.current().nextDouble(baseDelayNanos);
+        }
+
+        return (long) (baseDelayNanos + jitterDelay);
     }
 
     public static final class Builder {
@@ -97,6 +113,8 @@ public final class RetryPolicy {
         private int maxAttempts = 3;
         private Duration retryDelay = DEFAULT_RETRY_DELAY;
         private double backoffFactor = DEFAULT_BACKOFF_FACTOR;
+        private Duration maxInterval = DEFAULT_MAX_INTERVAL;
+        private boolean jitter = true;
         private Predicate<Throwable> retryOn;
 
         public Builder maxAttempts(int maxAttempts) {
@@ -121,6 +139,20 @@ public final class RetryPolicy {
                 throw new IllegalArgumentException("backoffFactor must be finite and at least one");
             }
             this.backoffFactor = backoffFactor;
+            return this;
+        }
+
+        public Builder maxInterval(Duration maxInterval) {
+            Objects.requireNonNull(maxInterval, "maxInterval cannot be null");
+            if (maxInterval.isNegative()) {
+                throw new IllegalArgumentException("maxInterval cannot be negative");
+            }
+            this.maxInterval = maxInterval;
+            return this;
+        }
+
+        public Builder jitter(boolean jitter) {
+            this.jitter = jitter;
             return this;
         }
 

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
@@ -33,79 +33,15 @@ public final class RetryPolicy {
     private final double backoffFactor;
     private final Predicate<Throwable> retryOn;
 
-    private RetryPolicy(
-            int maxAttempts,
-            Duration retryDelay,
-            double backoffFactor,
-            Predicate<Throwable> retryOn) {
-        this.maxAttempts = maxAttempts;
-        this.retryDelay = retryDelay;
-        this.backoffFactor = backoffFactor;
-        this.retryOn = retryOn;
+    private RetryPolicy(Builder builder) {
+        this.maxAttempts = builder.maxAttempts;
+        this.retryDelay = builder.retryDelay;
+        this.backoffFactor = builder.backoffFactor;
+        this.retryOn = builder.retryOn;
     }
 
-    @SafeVarargs
-    public static RetryPolicy of(int maxAttempts, Class<? extends Throwable>... exceptionTypes) {
-        return of(maxAttempts, DEFAULT_RETRY_DELAY, exceptionTypes);
-    }
-
-    @SafeVarargs
-    public static RetryPolicy of(
-            int maxAttempts,
-            Duration retryDelay,
-            Class<? extends Throwable>... exceptionTypes) {
-        return of(maxAttempts, retryDelay, DEFAULT_BACKOFF_FACTOR, exceptionTypes);
-    }
-
-    @SafeVarargs
-    public static RetryPolicy of(
-            int maxAttempts,
-            Duration retryDelay,
-            double backoffFactor,
-            Class<? extends Throwable>... exceptionTypes) {
-        Objects.requireNonNull(exceptionTypes, "exceptionTypes cannot be null");
-        if (exceptionTypes.length == 0) {
-            throw new IllegalArgumentException("exceptionTypes cannot be empty");
-        }
-
-        var types = Arrays.copyOf(exceptionTypes, exceptionTypes.length);
-        for (var type : types) {
-            Objects.requireNonNull(type, "exceptionTypes cannot contain null");
-        }
-
-        return of(maxAttempts, retryDelay, backoffFactor,
-                error -> Arrays.stream(types).anyMatch(type -> type.isInstance(error)));
-    }
-
-    public static RetryPolicy of(int maxAttempts, Predicate<? super Throwable> retryOn) {
-        return of(maxAttempts, DEFAULT_RETRY_DELAY, retryOn);
-    }
-
-    public static RetryPolicy of(
-            int maxAttempts,
-            Duration retryDelay,
-            Predicate<? super Throwable> retryOn) {
-        return of(maxAttempts, retryDelay, DEFAULT_BACKOFF_FACTOR, retryOn);
-    }
-
-    public static RetryPolicy of(
-            int maxAttempts,
-            Duration retryDelay,
-            double backoffFactor,
-            Predicate<? super Throwable> retryOn) {
-        if (maxAttempts < 1) {
-            throw new IllegalArgumentException("maxAttempts must be greater than zero");
-        }
-        Objects.requireNonNull(retryDelay, "retryDelay cannot be null");
-        if (retryDelay.isNegative()) {
-            throw new IllegalArgumentException("retryDelay cannot be negative");
-        }
-        if (!Double.isFinite(backoffFactor) || backoffFactor < 1) {
-            throw new IllegalArgumentException("backoffFactor must be finite and at least one");
-        }
-        Objects.requireNonNull(retryOn, "retryOn cannot be null");
-
-        return new RetryPolicy(maxAttempts, retryDelay, backoffFactor, retryOn::test);
+    public static Builder builder() {
+        return new Builder();
     }
 
     public <S extends AgentState> NodeHook.WrapCall<S> asHook() {
@@ -154,5 +90,67 @@ public final class RetryPolicy {
                 Long.MAX_VALUE);
         return runAsync(() -> {
         }, delayedExecutor((long) delayNanos, NANOSECONDS));
+    }
+
+    public static final class Builder {
+
+        private int maxAttempts = 3;
+        private Duration retryDelay = DEFAULT_RETRY_DELAY;
+        private double backoffFactor = DEFAULT_BACKOFF_FACTOR;
+        private Predicate<Throwable> retryOn;
+
+        public Builder maxAttempts(int maxAttempts) {
+            if (maxAttempts < 1) {
+                throw new IllegalArgumentException("maxAttempts must be greater than zero");
+            }
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        public Builder retryDelay(Duration retryDelay) {
+            Objects.requireNonNull(retryDelay, "retryDelay cannot be null");
+            if (retryDelay.isNegative()) {
+                throw new IllegalArgumentException("retryDelay cannot be negative");
+            }
+            this.retryDelay = retryDelay;
+            return this;
+        }
+
+        public Builder backoffFactor(double backoffFactor) {
+            if (!Double.isFinite(backoffFactor) || backoffFactor < 1) {
+                throw new IllegalArgumentException("backoffFactor must be finite and at least one");
+            }
+            this.backoffFactor = backoffFactor;
+            return this;
+        }
+
+        @SafeVarargs
+        public final Builder retryOn(Class<? extends Throwable>... exceptionTypes) {
+            Objects.requireNonNull(exceptionTypes, "exceptionTypes cannot be null");
+            if (exceptionTypes.length == 0) {
+                throw new IllegalArgumentException("exceptionTypes cannot be empty");
+            }
+
+            var types = Arrays.copyOf(exceptionTypes, exceptionTypes.length);
+            for (var type : types) {
+                Objects.requireNonNull(type, "exceptionTypes cannot contain null");
+            }
+
+            return retryOn(error -> Arrays.stream(types).anyMatch(type -> type.isInstance(error)));
+        }
+
+        public Builder retryOn(Predicate<? super Throwable> condition) {
+            Objects.requireNonNull(condition, "condition cannot be null");
+            Predicate<Throwable> predicate = condition::test;
+            retryOn = retryOn == null ? predicate : retryOn.or(predicate);
+            return this;
+        }
+
+        public RetryPolicy build() {
+            if (retryOn == null) {
+                throw new IllegalStateException("retryOn must be configured");
+            }
+            return new RetryPolicy(this);
+        }
     }
 }

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
@@ -18,7 +18,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.delayedExecutor;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static java.util.concurrent.CompletableFuture.runAsync;
-import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
@@ -27,14 +26,21 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public final class RetryPolicy {
 
     private static final Duration DEFAULT_RETRY_DELAY = Duration.ofMillis(500);
+    private static final double DEFAULT_BACKOFF_FACTOR = 2.0;
 
     private final int maxAttempts;
     private final Duration retryDelay;
+    private final double backoffFactor;
     private final Predicate<Throwable> retryOn;
 
-    private RetryPolicy(int maxAttempts, Duration retryDelay, Predicate<Throwable> retryOn) {
+    private RetryPolicy(
+            int maxAttempts,
+            Duration retryDelay,
+            double backoffFactor,
+            Predicate<Throwable> retryOn) {
         this.maxAttempts = maxAttempts;
         this.retryDelay = retryDelay;
+        this.backoffFactor = backoffFactor;
         this.retryOn = retryOn;
     }
 
@@ -48,6 +54,15 @@ public final class RetryPolicy {
             int maxAttempts,
             Duration retryDelay,
             Class<? extends Throwable>... exceptionTypes) {
+        return of(maxAttempts, retryDelay, DEFAULT_BACKOFF_FACTOR, exceptionTypes);
+    }
+
+    @SafeVarargs
+    public static RetryPolicy of(
+            int maxAttempts,
+            Duration retryDelay,
+            double backoffFactor,
+            Class<? extends Throwable>... exceptionTypes) {
         Objects.requireNonNull(exceptionTypes, "exceptionTypes cannot be null");
         if (exceptionTypes.length == 0) {
             throw new IllegalArgumentException("exceptionTypes cannot be empty");
@@ -58,7 +73,8 @@ public final class RetryPolicy {
             Objects.requireNonNull(type, "exceptionTypes cannot contain null");
         }
 
-        return of(maxAttempts, retryDelay, error -> Arrays.stream(types).anyMatch(type -> type.isInstance(error)));
+        return of(maxAttempts, retryDelay, backoffFactor,
+                error -> Arrays.stream(types).anyMatch(type -> type.isInstance(error)));
     }
 
     public static RetryPolicy of(int maxAttempts, Predicate<? super Throwable> retryOn) {
@@ -69,6 +85,14 @@ public final class RetryPolicy {
             int maxAttempts,
             Duration retryDelay,
             Predicate<? super Throwable> retryOn) {
+        return of(maxAttempts, retryDelay, DEFAULT_BACKOFF_FACTOR, retryOn);
+    }
+
+    public static RetryPolicy of(
+            int maxAttempts,
+            Duration retryDelay,
+            double backoffFactor,
+            Predicate<? super Throwable> retryOn) {
         if (maxAttempts < 1) {
             throw new IllegalArgumentException("maxAttempts must be greater than zero");
         }
@@ -76,9 +100,12 @@ public final class RetryPolicy {
         if (retryDelay.isNegative()) {
             throw new IllegalArgumentException("retryDelay cannot be negative");
         }
+        if (!Double.isFinite(backoffFactor) || backoffFactor < 1) {
+            throw new IllegalArgumentException("backoffFactor must be finite and at least one");
+        }
         Objects.requireNonNull(retryOn, "retryOn cannot be null");
 
-        return new RetryPolicy(maxAttempts, retryDelay, retryOn::test);
+        return new RetryPolicy(maxAttempts, retryDelay, backoffFactor, retryOn::test);
     }
 
     public <S extends AgentState> NodeHook.WrapCall<S> asHook() {
@@ -109,7 +136,7 @@ public final class RetryPolicy {
                 return CompletableFuture.<Map<String, Object>>failedFuture(cause);
             }
 
-            return delay().thenCompose(ignored -> apply(action, state, config, attempt + 1));
+            return delay(attempt).thenCompose(ignored -> apply(action, state, config, attempt + 1));
         })
                 .thenCompose(Function.identity());
     }
@@ -121,8 +148,11 @@ public final class RetryPolicy {
                         : error;
     }
 
-    private CompletableFuture<Void> delay() {
+    private CompletableFuture<Void> delay(int attempt) {
+        var delayNanos = Math.min(
+                retryDelay.toNanos() * Math.pow(backoffFactor, attempt - 1.0),
+                Long.MAX_VALUE);
         return runAsync(() -> {
-        }, delayedExecutor(retryDelay.toNanos(), NANOSECONDS));
+        }, delayedExecutor((long) delayNanos, NANOSECONDS));
     }
 }

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
@@ -1,0 +1,95 @@
+package org.bsc.langgraph4j.hook;
+
+import org.bsc.langgraph4j.RunnableConfig;
+import org.bsc.langgraph4j.action.AsyncNodeActionWithConfig;
+import org.bsc.langgraph4j.state.AgentState;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+/**
+ * Retries a node action when a configured failure occurs.
+ */
+public final class RetryPolicy {
+
+    private final int maxAttempts;
+    private final Predicate<Throwable> retryOn;
+
+    private RetryPolicy(int maxAttempts, Predicate<Throwable> retryOn) {
+        this.maxAttempts = maxAttempts;
+        this.retryOn = retryOn;
+    }
+
+    @SafeVarargs
+    public static RetryPolicy of(int maxAttempts, Class<? extends Throwable>... exceptionTypes) {
+        Objects.requireNonNull(exceptionTypes, "exceptionTypes cannot be null");
+        if (exceptionTypes.length == 0) {
+            throw new IllegalArgumentException("exceptionTypes cannot be empty");
+        }
+
+        var types = Arrays.copyOf(exceptionTypes, exceptionTypes.length);
+        for (var type : types) {
+            Objects.requireNonNull(type, "exceptionTypes cannot contain null");
+        }
+
+        return of(maxAttempts, error -> Arrays.stream(types).anyMatch(type -> type.isInstance(error)));
+    }
+
+    public static RetryPolicy of(int maxAttempts, Predicate<? super Throwable> retryOn) {
+        if (maxAttempts < 1) {
+            throw new IllegalArgumentException("maxAttempts must be greater than zero");
+        }
+        Objects.requireNonNull(retryOn, "retryOn cannot be null");
+
+        return new RetryPolicy(maxAttempts, retryOn::test);
+    }
+
+    public <S extends AgentState> NodeHook.WrapCall<S> asHook() {
+        return (nodeId, state, config, action) -> apply(action, state, config, 1);
+    }
+
+    private <S extends AgentState> CompletableFuture<Map<String, Object>> apply(
+            AsyncNodeActionWithConfig<S> action,
+            S state,
+            RunnableConfig config,
+            int attempt) {
+
+        CompletableFuture<Map<String, Object>> futureResult;
+
+        try {
+            futureResult = action.apply(state, config);
+        } catch (Throwable error) {
+            futureResult = failedFuture(error);
+        }
+
+        return futureResult.handle((result, error) -> {
+            if (error == null) {
+                return completedFuture(result);
+            }
+
+            var cause = unwrap(error);
+            if (attempt == maxAttempts || !retryOn.test(cause)) {
+                return CompletableFuture.<Map<String, Object>>failedFuture(cause);
+            }
+
+            return apply(action, state, config, attempt + 1);
+        })
+                .thenCompose(Function.identity());
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        return (error instanceof CompletionException || error instanceof ExecutionException)
+                && error.getCause() != null
+                        ? error.getCause()
+                        : error;
+    }
+}

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/hook/RetryPolicy.java
@@ -4,6 +4,7 @@ import org.bsc.langgraph4j.RunnableConfig;
 import org.bsc.langgraph4j.action.AsyncNodeActionWithConfig;
 import org.bsc.langgraph4j.state.AgentState;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -14,23 +15,39 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.delayedExecutor;
 import static java.util.concurrent.CompletableFuture.failedFuture;
+import static java.util.concurrent.CompletableFuture.runAsync;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * Retries a node action when a configured failure occurs.
  */
 public final class RetryPolicy {
 
+    private static final Duration DEFAULT_RETRY_DELAY = Duration.ofMillis(500);
+
     private final int maxAttempts;
+    private final Duration retryDelay;
     private final Predicate<Throwable> retryOn;
 
-    private RetryPolicy(int maxAttempts, Predicate<Throwable> retryOn) {
+    private RetryPolicy(int maxAttempts, Duration retryDelay, Predicate<Throwable> retryOn) {
         this.maxAttempts = maxAttempts;
+        this.retryDelay = retryDelay;
         this.retryOn = retryOn;
     }
 
     @SafeVarargs
     public static RetryPolicy of(int maxAttempts, Class<? extends Throwable>... exceptionTypes) {
+        return of(maxAttempts, DEFAULT_RETRY_DELAY, exceptionTypes);
+    }
+
+    @SafeVarargs
+    public static RetryPolicy of(
+            int maxAttempts,
+            Duration retryDelay,
+            Class<? extends Throwable>... exceptionTypes) {
         Objects.requireNonNull(exceptionTypes, "exceptionTypes cannot be null");
         if (exceptionTypes.length == 0) {
             throw new IllegalArgumentException("exceptionTypes cannot be empty");
@@ -41,16 +58,27 @@ public final class RetryPolicy {
             Objects.requireNonNull(type, "exceptionTypes cannot contain null");
         }
 
-        return of(maxAttempts, error -> Arrays.stream(types).anyMatch(type -> type.isInstance(error)));
+        return of(maxAttempts, retryDelay, error -> Arrays.stream(types).anyMatch(type -> type.isInstance(error)));
     }
 
     public static RetryPolicy of(int maxAttempts, Predicate<? super Throwable> retryOn) {
+        return of(maxAttempts, DEFAULT_RETRY_DELAY, retryOn);
+    }
+
+    public static RetryPolicy of(
+            int maxAttempts,
+            Duration retryDelay,
+            Predicate<? super Throwable> retryOn) {
         if (maxAttempts < 1) {
             throw new IllegalArgumentException("maxAttempts must be greater than zero");
         }
+        Objects.requireNonNull(retryDelay, "retryDelay cannot be null");
+        if (retryDelay.isNegative()) {
+            throw new IllegalArgumentException("retryDelay cannot be negative");
+        }
         Objects.requireNonNull(retryOn, "retryOn cannot be null");
 
-        return new RetryPolicy(maxAttempts, retryOn::test);
+        return new RetryPolicy(maxAttempts, retryDelay, retryOn::test);
     }
 
     public <S extends AgentState> NodeHook.WrapCall<S> asHook() {
@@ -81,7 +109,7 @@ public final class RetryPolicy {
                 return CompletableFuture.<Map<String, Object>>failedFuture(cause);
             }
 
-            return apply(action, state, config, attempt + 1);
+            return delay().thenCompose(ignored -> apply(action, state, config, attempt + 1));
         })
                 .thenCompose(Function.identity());
     }
@@ -91,5 +119,10 @@ public final class RetryPolicy {
                 && error.getCause() != null
                         ? error.getCause()
                         : error;
+    }
+
+    private CompletableFuture<Void> delay() {
+        return runAsync(() -> {
+        }, delayedExecutor(retryDelay.toNanos(), NANOSECONDS));
     }
 }

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
@@ -1,0 +1,118 @@
+package org.bsc.langgraph4j.hook;
+
+import org.bsc.langgraph4j.RunnableConfig;
+import org.bsc.langgraph4j.action.AsyncNodeActionWithConfig;
+import org.bsc.langgraph4j.state.AgentState;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RetryPolicyTest {
+
+    static class State extends AgentState {
+        State(Map<String, Object> data) {
+            super(data);
+        }
+    }
+
+    @Test
+    void retriesRetryableFailureUntilSuccess() {
+        var attempts = new AtomicInteger();
+
+        AsyncNodeActionWithConfig<State> action = (state, config) -> {
+            if (attempts.incrementAndGet() < 3) {
+                return failedFuture(new IOException("temporary failure"));
+            }
+
+            return completedFuture(Map.of("result", "done"));
+        };
+
+        NodeHook.WrapCall<State> hook = RetryPolicy.of(3, IOException.class).asHook();
+
+        var future = hook.applyWrap(
+                "call_api",
+                new State(Map.of()),
+                RunnableConfig.empty(),
+                action);
+
+        assertEquals(3, attempts.get());
+        assertEquals("done", future.join().get("result"));
+    }
+
+    @Test
+    void retriesSynchronousRetryableFailureUntilSuccess() {
+        var attempts = new AtomicInteger();
+
+        AsyncNodeActionWithConfig<State> action = (state, config) -> {
+            if (attempts.incrementAndGet() < 3) {
+                throw new IllegalStateException("temporary failure");
+            }
+
+            return completedFuture(Map.of("result", "done"));
+        };
+
+        NodeHook.WrapCall<State> hook = RetryPolicy.of(3, IllegalStateException.class).asHook();
+
+        var result = hook.applyWrap(
+                "call_api",
+                new State(Map.of()),
+                RunnableConfig.empty(),
+                action);
+
+        assertEquals(3, attempts.get());
+        assertEquals("done", result.join().get("result"));
+    }
+
+    @Test
+    void doesNotRetryNonRetryableFailure() {
+        var attempts = new AtomicInteger();
+
+        AsyncNodeActionWithConfig<State> action = (state, config) -> {
+            attempts.incrementAndGet();
+            return failedFuture(new IOException("temporary failure"));
+        };
+
+        NodeHook.WrapCall<State> hook = RetryPolicy.of(3, IllegalStateException.class).asHook();
+
+        var future = hook.applyWrap(
+                "call_api",
+                new State(Map.of()),
+                RunnableConfig.empty(),
+                action);
+
+        var error = assertThrows(CompletionException.class, future::join);
+
+        assertEquals(1, attempts.get());
+        assertInstanceOf(IOException.class, error.getCause());
+    }
+
+    @Test
+    void stopsAfterMaxAttempts() {
+        var attempts = new AtomicInteger();
+
+        AsyncNodeActionWithConfig<State> action = (state, config) -> {
+            attempts.incrementAndGet();
+            return failedFuture(new IOException("temporary failure"));
+        };
+
+        NodeHook.WrapCall<State> hook = RetryPolicy.of(3, IOException.class).asHook();
+
+        var future = hook.applyWrap(
+                "call_api",
+                new State(Map.of()),
+                RunnableConfig.empty(),
+                action);
+
+        assertThrows(CompletionException.class, future::join);
+        assertEquals(3, attempts.get());
+    }
+}

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
@@ -38,7 +38,10 @@ class RetryPolicyTest {
             return completedFuture(Map.of("result", "done"));
         };
 
-        NodeHook.WrapCall<State> hook = RetryPolicy.of(3, IOException.class).asHook();
+        NodeHook.WrapCall<State> hook = RetryPolicy.builder()
+                .retryOn(IOException.class)
+                .build()
+                .asHook();
 
         var future = hook.applyWrap(
                 "call_api",
@@ -46,10 +49,8 @@ class RetryPolicyTest {
                 RunnableConfig.empty(),
                 action);
 
-        var result = future.join();
-
         assertEquals(3, attempts.get());
-        assertEquals("done", result.get("result"));
+        assertEquals("done", future.join().get("result"));
     }
 
     @Test
@@ -64,7 +65,10 @@ class RetryPolicyTest {
             return completedFuture(Map.of("result", "done"));
         };
 
-        NodeHook.WrapCall<State> hook = RetryPolicy.of(3, IllegalStateException.class).asHook();
+        NodeHook.WrapCall<State> hook = RetryPolicy.builder()
+                .retryOn(IllegalStateException.class)
+                .build()
+                .asHook();
 
         var result = hook.applyWrap(
                 "call_api",
@@ -72,19 +76,23 @@ class RetryPolicyTest {
                 RunnableConfig.empty(),
                 action);
 
-        var output = result.join();
-
         assertEquals(3, attempts.get());
-        assertEquals("done", output.get("result"));
+        assertEquals("done", result.join().get("result"));
     }
 
     @Test
     void delaysRetry() {
         var attempts = new AtomicInteger();
+
         AsyncNodeActionWithConfig<State> action = (state, config) -> attempts.incrementAndGet() == 1
                 ? failedFuture(new IOException("temporary failure"))
                 : completedFuture(Map.of("result", "done"));
-        NodeHook.WrapCall<State> hook = RetryPolicy.of(2, IOException.class).asHook();
+
+        NodeHook.WrapCall<State> hook = RetryPolicy.builder()
+                .maxAttempts(2)
+                .retryOn(IOException.class)
+                .build()
+                .asHook();
 
         var start = System.nanoTime();
         var result = hook.applyWrap("call_api", new State(Map.of()), RunnableConfig.empty(), action).join();
@@ -101,8 +109,13 @@ class RetryPolicyTest {
         AsyncNodeActionWithConfig<State> action = (state, config) -> attempts.incrementAndGet() < 3
                 ? failedFuture(new IOException("temporary failure"))
                 : completedFuture(Map.of("result", "done"));
-        NodeHook.WrapCall<State> hook = RetryPolicy.of(
-                3, Duration.ofMillis(50), 2.0, IOException.class).asHook();
+
+        NodeHook.WrapCall<State> hook = RetryPolicy.builder()
+                .retryDelay(Duration.ofMillis(50))
+                .backoffFactor(2.0)
+                .retryOn(IOException.class)
+                .build()
+                .asHook();
 
         var start = System.nanoTime();
         var result = hook.applyWrap("call_api", new State(Map.of()), RunnableConfig.empty(), action).join();
@@ -122,7 +135,10 @@ class RetryPolicyTest {
             return failedFuture(new IOException("temporary failure"));
         };
 
-        NodeHook.WrapCall<State> hook = RetryPolicy.of(3, IllegalStateException.class).asHook();
+        NodeHook.WrapCall<State> hook = RetryPolicy.builder()
+                .retryOn(IllegalStateException.class)
+                .build()
+                .asHook();
 
         var future = hook.applyWrap(
                 "call_api",
@@ -145,7 +161,10 @@ class RetryPolicyTest {
             return failedFuture(new IOException("temporary failure"));
         };
 
-        NodeHook.WrapCall<State> hook = RetryPolicy.of(3, IOException.class).asHook();
+        NodeHook.WrapCall<State> hook = RetryPolicy.builder()
+                .retryOn(IOException.class)
+                .build()
+                .asHook();
 
         var future = hook.applyWrap(
                 "call_api",

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
@@ -49,8 +49,10 @@ class RetryPolicyTest {
                 RunnableConfig.empty(),
                 action);
 
+        var result = future.join();
+
         assertEquals(3, attempts.get());
-        assertEquals("done", future.join().get("result"));
+        assertEquals("done", result.get("result"));
     }
 
     @Test
@@ -76,8 +78,10 @@ class RetryPolicyTest {
                 RunnableConfig.empty(),
                 action);
 
+        var output = result.join();
+
         assertEquals(3, attempts.get());
-        assertEquals("done", result.join().get("result"));
+        assertEquals("done", output.get("result"));
     }
 
     @Test
@@ -124,6 +128,35 @@ class RetryPolicyTest {
         assertEquals(3, attempts.get());
         assertEquals("done", result.get("result"));
         assertTrue(elapsed.compareTo(Duration.ofMillis(125)) >= 0);
+    }
+
+    @Test
+    void capsBackoffDelayAtMaxInterval() {
+        var retry = RetryPolicy.builder()
+                .retryDelay(Duration.ofMillis(50))
+                .backoffFactor(2.0)
+                .maxInterval(Duration.ofMillis(75))
+                .jitter(false)
+                .retryOn(IOException.class)
+                .build();
+
+        assertEquals(Duration.ofMillis(50).toNanos(), retry.delayNanos(1));
+        assertEquals(Duration.ofMillis(75).toNanos(), retry.delayNanos(2));
+        assertEquals(Duration.ofMillis(75).toNanos(), retry.delayNanos(3));
+    }
+
+    @Test
+    void addsJitterAfterCappingDelay() {
+        var retry = RetryPolicy.builder()
+                .retryDelay(Duration.ofMillis(50))
+                .maxInterval(Duration.ofMillis(75))
+                .retryOn(IOException.class)
+                .build();
+
+        var delay = retry.delayNanos(2);
+
+        assertTrue(delay >= Duration.ofMillis(75).toNanos());
+        assertTrue(delay < Duration.ofMillis(150).toNanos());
     }
 
     @Test

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
@@ -96,6 +96,24 @@ class RetryPolicyTest {
     }
 
     @Test
+    void increasesDelayForEachRetry() {
+        var attempts = new AtomicInteger();
+        AsyncNodeActionWithConfig<State> action = (state, config) -> attempts.incrementAndGet() < 3
+                ? failedFuture(new IOException("temporary failure"))
+                : completedFuture(Map.of("result", "done"));
+        NodeHook.WrapCall<State> hook = RetryPolicy.of(
+                3, Duration.ofMillis(50), 2.0, IOException.class).asHook();
+
+        var start = System.nanoTime();
+        var result = hook.applyWrap("call_api", new State(Map.of()), RunnableConfig.empty(), action).join();
+        var elapsed = Duration.ofNanos(System.nanoTime() - start);
+
+        assertEquals(3, attempts.get());
+        assertEquals("done", result.get("result"));
+        assertTrue(elapsed.compareTo(Duration.ofMillis(125)) >= 0);
+    }
+
+    @Test
     void doesNotRetryNonRetryableFailure() {
         var attempts = new AtomicInteger();
 

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/hook/RetryPolicyTest.java
@@ -6,6 +6,7 @@ import org.bsc.langgraph4j.state.AgentState;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -15,6 +16,7 @@ import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RetryPolicyTest {
 
@@ -44,8 +46,10 @@ class RetryPolicyTest {
                 RunnableConfig.empty(),
                 action);
 
+        var result = future.join();
+
         assertEquals(3, attempts.get());
-        assertEquals("done", future.join().get("result"));
+        assertEquals("done", result.get("result"));
     }
 
     @Test
@@ -68,8 +72,27 @@ class RetryPolicyTest {
                 RunnableConfig.empty(),
                 action);
 
+        var output = result.join();
+
         assertEquals(3, attempts.get());
-        assertEquals("done", result.join().get("result"));
+        assertEquals("done", output.get("result"));
+    }
+
+    @Test
+    void delaysRetry() {
+        var attempts = new AtomicInteger();
+        AsyncNodeActionWithConfig<State> action = (state, config) -> attempts.incrementAndGet() == 1
+                ? failedFuture(new IOException("temporary failure"))
+                : completedFuture(Map.of("result", "done"));
+        NodeHook.WrapCall<State> hook = RetryPolicy.of(2, IOException.class).asHook();
+
+        var start = System.nanoTime();
+        var result = hook.applyWrap("call_api", new State(Map.of()), RunnableConfig.empty(), action).join();
+        var elapsed = Duration.ofNanos(System.nanoTime() - start);
+
+        assertEquals(2, attempts.get());
+        assertEquals("done", result.get("result"));
+        assertTrue(elapsed.compareTo(Duration.ofMillis(450)) >= 0);
     }
 
     @Test

--- a/src/site/mkdocs/core/hooks.md
+++ b/src/site/mkdocs/core/hooks.md
@@ -99,8 +99,22 @@ When multiple hooks are registered for the same node or edge, they are executed 
 *   **`AfterCall` Hooks**: Also executed in a **LIFO** order.
 *   **`WrapCall` Hooks**: Executed in a **FIFO** (First-In, First-Out) order. The first hook added is the first one to wrap the action, meaning its "before" logic runs first, and its "after" logic runs last.
 
+## Retrying Nodes
+
+`RetryPolicy` is a node-specific `WrapCall` hook for retrying transient failures. Failed attempts do not reach state merging or checkpointing; the graph continues only when the node action succeeds.
+
+```java
+var retry = RetryPolicy.of(3, IOException.class);
+
+var graph = new StateGraph<>(State.SCHEMA, State::new)
+        .addNode("call_api", callApi)
+        .addEdge(START, "call_api")
+        .addEdge("call_api", END)
+        .addWrapCallNodeHook("call_api", retry.asHook());
+```
+
+Apply retry policies only to idempotent operations, or operations that have their own idempotency key, to avoid repeated side effects.
+
 ## Code Examples
 
 See [Hooks samples notebook](how-tos/hooks.ipynb)
-
-

--- a/src/site/mkdocs/core/hooks.md
+++ b/src/site/mkdocs/core/hooks.md
@@ -104,7 +104,13 @@ When multiple hooks are registered for the same node or edge, they are executed 
 `RetryPolicy` is a node-specific `WrapCall` hook for retrying transient failures. Failed attempts do not reach state merging or checkpointing; the graph continues only when the node action succeeds.
 
 ```java
-var retry = RetryPolicy.of(3, IOException.class);
+var retry = RetryPolicy.builder()
+        .maxAttempts(3)
+        .retryDelay(Duration.ofMillis(500))
+        .backoffFactor(2.0)
+        .retryOn(IOException.class, TimeoutException.class)
+        .retryOn(error -> error instanceof RemoteServiceException)
+        .build();
 
 var graph = new StateGraph<>(State.SCHEMA, State::new)
         .addNode("call_api", callApi)
@@ -112,6 +118,14 @@ var graph = new StateGraph<>(State.SCHEMA, State::new)
         .addEdge("call_api", END)
         .addWrapCallNodeHook("call_api", retry.asHook());
 ```
+
+`retryOn(...)` is required. It accepts one or more exception classes or a predicate; multiple calls are combined with OR.
+
+The other builder options are optional:
+
+* `maxAttempts(int)` defaults to `3` and includes the initial invocation.
+* `retryDelay(Duration)` defaults to `500 ms` and is the delay before the first retry.
+* `backoffFactor(double)` defaults to `2.0`; each following retry delay is multiplied by this factor.
 
 Apply retry policies only to idempotent operations, or operations that have their own idempotency key, to avoid repeated side effects.
 

--- a/src/site/mkdocs/core/hooks.md
+++ b/src/site/mkdocs/core/hooks.md
@@ -108,6 +108,8 @@ var retry = RetryPolicy.builder()
         .maxAttempts(3)
         .retryDelay(Duration.ofMillis(500))
         .backoffFactor(2.0)
+        .maxInterval(Duration.ofSeconds(128))
+        .jitter(true)
         .retryOn(IOException.class, TimeoutException.class)
         .retryOn(error -> error instanceof RemoteServiceException)
         .build();
@@ -126,6 +128,8 @@ The other builder options are optional:
 * `maxAttempts(int)` defaults to `3` and includes the initial invocation.
 * `retryDelay(Duration)` defaults to `500 ms` and is the delay before the first retry.
 * `backoffFactor(double)` defaults to `2.0`; each following retry delay is multiplied by this factor.
+* `maxInterval(Duration)` defaults to `128 s` and caps the backoff delay before jitter is added.
+* `jitter(boolean)` defaults to `true` and adds a random delay from zero up to the capped delay. With jitter enabled, the actual delay can be nearly twice `maxInterval`.
 
 Apply retry policies only to idempotent operations, or operations that have their own idempotency key, to avoid repeated side effects.
 


### PR DESCRIPTION
### Summary

Adds `RetryPolicy`, a node-specific `WrapCall` hook for retrying transient node failures.

- Supports retry conditions by exception type or predicate.
- Retries synchronous throws and failed `CompletableFuture`s.
- Adds configurable attempts, initial delay, exponential backoff, maximum interval, and jitter.
- Keeps failed attempts outside state merging and checkpointing.
- Documents the builder API and adds retry coverage.

### Usage

```java
var retry = RetryPolicy.builder()
        .maxAttempts(3)
        .retryDelay(Duration.ofMillis(500))
        .backoffFactor(2.0)
        .maxInterval(Duration.ofSeconds(128))
        .jitter(true)
        .retryOn(IOException.class, TimeoutException.class)
        .retryOn(error -> error instanceof RemoteServiceException)
        .build();

var graph = new StateGraph<>(State.SCHEMA, State::new)
        .addNode("call_api", callApi)
        .addEdge(START, "call_api")
        .addEdge("call_api", END)
        .addWrapCallNodeHook("call_api", retry.asHook());
 ```
 
`retryOn(...)` is required. Multiple calls are combined with OR.

## Defaults

| Option | Default | Description |
| --- | --- | --- |
| `maxAttempts` | `3` | Includes the initial invocation. |
| `retryDelay` | `500 ms` | Delay before the first retry. |
| `backoffFactor` | `2.0` | Multiplier for each subsequent retry delay. |
| `maxInterval` | `128 s` | Caps the exponential base delay before jitter. |
| `jitter` | `true` | Adds a random delay up to the capped base delay. |

The maximum interval caps the exponential base delay. When jitter is enabled, a random delay up to the capped base delay is added.