### PR TITLE
fix(core): preserve distinct appender values with colliding hashes

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/state/AppenderChannel.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/state/AppenderChannel.java
@@ -56,8 +56,8 @@ public class AppenderChannel<T> implements Channel<List<T>>, LG4JLoggable {
                 return right;
             }
             for (T rValue : right) {
-                // remove duplicate
-                if (left.stream().noneMatch(lValue -> Objects.hash(lValue) == Objects.hash(rValue))) {
+                // Keep distinct values even when their hash codes collide.
+                if (left.stream().noneMatch(lValue -> Objects.equals(lValue, rValue))) {
                     left.add(rValue);
                 }
             }

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/state/AgentStateTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/state/AgentStateTest.java
@@ -136,4 +136,21 @@ public class AgentStateTest {
         assertIterableEquals( List.of( "x1", "v1", "v2", "v3"), state.messages() );
     }
 
+    @Test
+    public void appenderKeepsDistinctValuesWithCollidingHashCodes() {
+        var schema = Map.<String, Channel<?>>of("messages", Channels.appender(ArrayList::new));
+        var state = new State(Map.of("messages", new ArrayList<>(List.of("FB"))));
+
+        // "FB" and "Ea" are unequal strings with the same hash code in Java.
+        assertNotEquals("FB", "Ea");
+        assertEquals("FB".hashCode(), "Ea".hashCode());
+
+        var newStateData = AgentState.updateState(
+                state,
+                Map.of("messages", "Ea"),
+                schema);
+
+        assertIterableEquals(List.of("FB", "Ea"), (List<?>) newStateData.get("messages"));
+    }
+
 }


### PR DESCRIPTION
## Summary

- compare appender values with `Objects.equals(...)` instead of treating matching hash codes as equality
- add a regression test that exercises the fix through `AgentState.updateState(...)`
- document why the known `"FB"` / `"Ea"` collision pair is used in the test

## Problem

`AppenderChannel.ReducerDisallowDuplicate` currently drops a new value whenever its hash code matches an existing value. Since hash collisions are valid in Java, distinct state values can be silently discarded.

## Verification

- confirmed the regression test fails before the production change (`expected: 2`, `actual: 1`)
- `./mvnw -q -pl langgraph4j-core -Dtest=AgentStateTest test`
- `./mvnw -q -pl langgraph4j-core test`

Closes #447
