### PR TITLE
feat(core): add per-invocation recursion limit

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/CompiledGraph.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/CompiledGraph.java
@@ -853,9 +853,10 @@ public final class CompiledGraph<State extends AgentState> implements GraphDefin
 
             try {
                 // GUARD: CHECK MAX ITERATION REACHED
-                if( ++iteration > maxIterations ) {
-                    // log.warn( "Maximum number of iterations ({}) reached!", maxIterations);
-                    return Data.error( new IllegalStateException( format("Maximum number of iterations (%d) reached!", maxIterations)) );
+                final int recursionLimit = config.recursionLimit().orElse(maxIterations);
+                if( ++iteration > recursionLimit ) {
+                    // log.warn( "Maximum number of iterations ({}) reached!", recursionLimit);
+                    return Data.error( new IllegalStateException( format("Maximum number of iterations (%d) reached!", recursionLimit)) );
                 }
 
                 // GUARD: CHECK IF IT IS END

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/RunnableConfig.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/RunnableConfig.java
@@ -44,6 +44,7 @@ public final class RunnableConfig implements HasMetadata {
     private final String checkPointId;
     private final String nextNode;
     private final CompiledGraph.StreamMode streamMode;
+    private final Integer recursionLimit;
     private final Map<String,Object> metadata;
 
     private RunnableConfig() {
@@ -51,6 +52,7 @@ public final class RunnableConfig implements HasMetadata {
         this.checkPointId = null;
         this.nextNode = null;
         this.streamMode = CompiledGraph.StreamMode.VALUES;
+        this.recursionLimit = null;
         this.metadata = null;
     }
 
@@ -64,16 +66,18 @@ public final class RunnableConfig implements HasMetadata {
         this.checkPointId   = builder.checkPointId;
         this.nextNode       = builder.nextNode;
         this.streamMode     = builder.streamMode;
+        this.recursionLimit = builder.recursionLimit;
         this.metadata       = builder.metadata();
     }
 
     @Override
     public String toString() {
-        return  "RunnableConfig{ threadId=%s, checkPointId=%s, nextNode=%s, streamMode=%s } metadata: %s".formatted(
+        return  "RunnableConfig{ threadId=%s, checkPointId=%s, nextNode=%s, streamMode=%s, recursionLimit=%s } metadata: %s".formatted(
                 threadId,
                 checkPointId,
                 nextNode,
                 streamMode,
+                recursionLimit,
                 CollectionsUtils.toString(metadata)
         );
     }
@@ -86,6 +90,16 @@ public final class RunnableConfig implements HasMetadata {
     public CompiledGraph.StreamMode streamMode() {
         return streamMode;
     }
+
+    /**
+     * Returns the maximum number of iterations allowed for this invocation.
+     *
+     * @return an optional recursion limit, or empty when the graph default should be used
+     */
+    public Optional<Integer> recursionLimit() {
+        return ofNullable(recursionLimit);
+    }
+
     /**
      * Returns the thread ID as an {@link Optional}.
      *
@@ -242,6 +256,7 @@ public final class RunnableConfig implements HasMetadata {
         private String checkPointId;
         private String nextNode;
         private CompiledGraph.StreamMode streamMode = CompiledGraph.StreamMode.VALUES;
+        private Integer recursionLimit;
 
         /**
          * Constructs a new instance of the {@link Builder} with default configuration settings.
@@ -259,6 +274,7 @@ public final class RunnableConfig implements HasMetadata {
             this.checkPointId   = config.checkPointId;
             this.nextNode       = config.nextNode;
             this.streamMode     = config.streamMode;
+            this.recursionLimit = config.recursionLimit;
 
         }
 
@@ -304,6 +320,20 @@ public final class RunnableConfig implements HasMetadata {
          */
         public Builder streamMode(CompiledGraph.StreamMode streamMode) {
             this.streamMode = streamMode;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of iterations allowed for this invocation.
+         *
+         * @param recursionLimit the maximum number of iterations, greater than zero
+         * @return this builder
+         */
+        public Builder recursionLimit(int recursionLimit) {
+            if (recursionLimit <= 0) {
+                throw new IllegalArgumentException("recursionLimit must be > 0!");
+            }
+            this.recursionLimit = recursionLimit;
             return this;
         }
 

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/RecursionLimitTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/RecursionLimitTest.java
@@ -1,0 +1,63 @@
+package org.bsc.langgraph4j;
+
+import org.bsc.langgraph4j.action.AsyncNodeAction;
+import org.bsc.langgraph4j.state.AgentState;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.bsc.langgraph4j.StateGraph.START;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RecursionLimitTest {
+
+    private CompiledGraph<AgentState> loopingGraph(int recursionLimit) throws Exception {
+        return new StateGraph<>(AgentState::new)
+                .addNode("loop", AsyncNodeAction.node_async(state -> Map.of()))
+                .addEdge(START, "loop")
+                .addEdge("loop", "loop")
+                .compile(CompileConfig.builder().recursionLimit(recursionLimit).build());
+    }
+
+    private void assertRecursionLimit(Exception exception, int recursionLimit) {
+        Throwable cause = exception;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        assertEquals("Maximum number of iterations (%d) reached!".formatted(recursionLimit), cause.getMessage());
+    }
+
+    @Test
+    void compileConfigRecursionLimitIsUsedWithoutAnOverride() throws Exception {
+        var graph = loopingGraph(3);
+
+        var exception = assertThrows(Exception.class, () -> graph.invoke(Map.of()));
+
+        assertRecursionLimit(exception, 3);
+    }
+
+    @Test
+    void runnableConfigRecursionLimitOverridesTheGraphDefault() throws Exception {
+        var graph = loopingGraph(2);
+
+        var exception = assertThrows(Exception.class,
+                () -> graph.invoke(Map.of(), RunnableConfig.builder().recursionLimit(4).build()));
+
+        assertRecursionLimit(exception, 4);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void runnableConfigRecursionLimitOverridesLegacyMaxIterations() throws Exception {
+        var graph = loopingGraph(2);
+        graph.setMaxIterations(3);
+
+        var legacyException = assertThrows(Exception.class, () -> graph.invoke(Map.of()));
+        assertRecursionLimit(legacyException, 3);
+
+        var overrideException = assertThrows(Exception.class,
+                () -> graph.invoke(Map.of(), RunnableConfig.builder().recursionLimit(4).build()));
+        assertRecursionLimit(overrideException, 4);
+    }
+}

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/RecursionLimitTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/RecursionLimitTest.java
@@ -1,14 +1,17 @@
 package org.bsc.langgraph4j;
 
 import org.bsc.langgraph4j.action.AsyncNodeAction;
+import org.bsc.langgraph4j.action.AsyncNodeActionWithConfig;
 import org.bsc.langgraph4j.state.AgentState;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.bsc.langgraph4j.StateGraph.START;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RecursionLimitTest {
 
@@ -59,5 +62,27 @@ class RecursionLimitTest {
         var overrideException = assertThrows(Exception.class,
                 () -> graph.invoke(Map.of(), RunnableConfig.builder().recursionLimit(4).build()));
         assertRecursionLimit(overrideException, 4);
+    }
+
+    @Test
+    void recursionLimitIsPropagatedToCompiledSubgraphs() throws Exception {
+        var subgraph = new StateGraph<>(AgentState::new)
+                .addNode("node", AsyncNodeActionWithConfig.node_async((state, config) -> {
+                    assertEquals(Optional.of(7), config.recursionLimit());
+                    return Map.of();
+                }))
+                .addEdge(START, "node")
+                .addEdge("node", StateGraph.END)
+                .compile();
+
+        var graph = new StateGraph<>(AgentState::new)
+                .addNode("subgraph", subgraph)
+                .addEdge(START, "subgraph")
+                .addEdge("subgraph", StateGraph.END)
+                .compile();
+
+        var result = graph.invoke(Map.of(), RunnableConfig.builder().recursionLimit(7).build());
+
+        assertTrue(result.isPresent());
     }
 }

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/RunnableConfigTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/RunnableConfigTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RunnableConfigTest {
@@ -27,5 +28,26 @@ public class RunnableConfigTest {
         assertEquals( "test2", config.metadata("nodeId").get() );
         assertTrue( config.metadata("graphPath").isPresent() );
         assertEquals( "test1/test2", config.metadata("graphPath").get() );
+    }
+
+    @Test
+    public void recursionLimitIsPreservedByConfigCopies() {
+        var config = RunnableConfig.builder()
+                .recursionLimit(10)
+                .build();
+
+        assertEquals(10, config.recursionLimit().orElseThrow());
+        assertEquals(10, RunnableConfig.builder(config).build().recursionLimit().orElseThrow());
+        assertEquals(10, config.withStreamMode(CompiledGraph.StreamMode.SNAPSHOTS).recursionLimit().orElseThrow());
+        assertEquals(10, config.withCheckPointId("checkpoint-1").recursionLimit().orElseThrow());
+        assertEquals(10, config.updateMetadata(Map.of("key", "value")).recursionLimit().orElseThrow());
+    }
+
+    @Test
+    public void recursionLimitMustBePositive() {
+        assertThrows(IllegalArgumentException.class,
+                () -> RunnableConfig.builder().recursionLimit(0));
+        assertThrows(IllegalArgumentException.class,
+                () -> RunnableConfig.builder().recursionLimit(-1));
     }
 }

--- a/src/site/mkdocs/core/core-library.md
+++ b/src/site/mkdocs/core/core-library.md
@@ -70,7 +70,7 @@ var graph = graphBuilder.compile(compileConfig);
 | **interruptBefore** | `Set<String>` | empty | Node names where the graph should pause **before** executing the node. Useful for inspecting state before a node runs or for getting human approval before proceeding. |
 | **interruptsAfter** | `Set<String>` | empty | Node names where the graph should pause **after** executing the node. Useful for inspecting results after a node completes or for user feedback. |
 | **interruptBeforeEdge** | `boolean` | `false` | If `true`, interruptions at a node occur **after** it executes but **before** any conditional edges are evaluated. This allows inspecting the state before the graph branches to the next node. |
-| **recursionLimit** | `int` | `25` | Maximum recursion depth allowed during graph execution. Prevents infinite loops by raising an error if the graph exceeds this limit. Increase if your graph needs deep execution paths. |
+| **recursionLimit** | `int` | `25` | Default maximum number of execution steps allowed for each graph invocation. Prevents infinite loops by raising an error if the limit is exceeded. A `RunnableConfig` recursion limit overrides this default for one invocation. |
 | **releaseThread** | `boolean` | `false` | If `true`, the checkpointer will release all data associated to the current thread acquired during graph execution. |
 | **graphId** | `String` | `null` | Optional identifier for the graph. Useful for logging, monitoring, or distinguishing between multiple graph instances. It will available through `RunnableConfig.graphId()`|
 
@@ -129,6 +129,7 @@ You provide a `RunnableConfig` when invoking the graph:
 var config = RunnableConfig.builder()
                           .threadId("user-123")
                           .streamMode(CompiledGraph.StreamMode.UPDATES)
+                          .recursionLimit(50)
                           .putMetadata("userId", "user-123")
                           .putMetadata("model", "gpt-4")
                           .build();
@@ -144,6 +145,7 @@ graph.stream(inputs, config);
 | **checkPointId** | `String` | Specific checkpoint identifier within a thread. Useful for resuming execution from a specific point rather than from the beginning. |
 | **nextNode** | `String` | Specifies which node should execute next. Primarily used internally by the graph engine when resuming interrupted executions. |
 | **streamMode** | `CompiledGraph.StreamMode` | Controls how results are streamed during execution. Options are `VALUES` (full state after each step) or `UPDATES` (only state changes). Defaults to `VALUES`. |
+| **recursionLimit** | `int` | Maximum number of execution steps for this invocation. Overrides the `CompileConfig` default and must be greater than zero. |
 | **metadata** | `Map<String, Object>` | Custom key-value pairs available throughout execution. Useful for passing runtime context like user IDs, API keys, feature flags, or model selection that nodes and edges need access to. |
 
 ##### Reserved attributes' metadata


### PR DESCRIPTION
## Summary

- add `RunnableConfig.recursionLimit(int)` for per-invocation execution limits
- use the runtime limit before falling back to the compiled graph default
- preserve recursion limits when copying or modifying `RunnableConfig`
- cover runtime overrides, validation, and compiled subgraph propagation
- document the `RunnableConfig` override and `CompileConfig` fallback