### PR TITLE
fix(core): preserve final state from parallel streaming nodes

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/internal/node/ParallelNode.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/internal/node/ParallelNode.java
@@ -1,6 +1,7 @@
 package org.bsc.langgraph4j.internal.node;
 
 import org.bsc.async.AsyncGenerator;
+import org.bsc.langgraph4j.GraphResult;
 import org.bsc.langgraph4j.NodeOutput;
 import org.bsc.langgraph4j.RunnableConfig;
 import org.bsc.langgraph4j.action.AsyncNodeActionWithConfig;
@@ -30,7 +31,9 @@ public class ParallelNode<State extends AgentState> extends Node<State> {
             Map<String, Channel<?>> channels) implements AsyncNodeActionWithConfig<State> {
 
         private CompletableFuture<Map<String, Object>> evalGenerator(AsyncGenerator<NodeOutput<State>> generator, Map<String, Object> initPartialState) {
-            return generator.reduce(new ArrayList<NodeOutput<State>>(), (result, value) -> {
+
+            final var embedGenerator = new AsyncGenerator.WithEmbed<>(generator);
+            return embedGenerator.reduce(new ArrayList<NodeOutput<State>>(), (result, value) -> {
                         result.add(value);
                         return result;
                     })
@@ -39,8 +42,26 @@ public class ParallelNode<State extends AgentState> extends Node<State> {
                         for (var output : list) {
                             result = AgentState.updateState(result, output.state().data(), channels);
                         }
-                        return result;
-                    });
+                        return mergeGeneratorResultValue(embedGenerator, result);
+                    })
+                    .whenComplete((result, error) -> embedGenerator.close());
+        }
+
+        // merges the generator result value into the branch partial state, like embedGenerator() on the serial path
+        private Map<String, Object> mergeGeneratorResultValue(AsyncGenerator.WithEmbed<NodeOutput<State>> generator, Map<String, Object> partialState) {
+
+            final var result = GraphResult.from(generator);
+
+            if (result.isEmpty() || result.isCancelled()) {
+                return partialState;
+            }
+            if (result.isStateDataOrCheckpointSaverTag()) {
+                return AgentState.updateState(partialState, result.asStateDataOrLastCheckpointStateData(), channels);
+            }
+            if (result.isInterruptionMetadata()) {
+                throw new UnsupportedOperationException("Interruption metadata cannot be returned from a parallel branch streaming generator");
+            }
+            throw new IllegalArgumentException("Unsupported parallel branch streaming result type: %s".formatted(result.type()));
         }
 
         @SuppressWarnings("unchecked")

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/ParallelNodeTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/ParallelNodeTest.java
@@ -1,16 +1,23 @@
 package org.bsc.langgraph4j;
 
 
+import org.bsc.async.AsyncGenerator;
+import org.bsc.async.AsyncGeneratorQueue;
 import org.bsc.langgraph4j.action.AsyncNodeActionWithConfig;
+import org.bsc.langgraph4j.action.InterruptionMetadata;
+import org.bsc.langgraph4j.checkpoint.BaseCheckpointSaver;
+import org.bsc.langgraph4j.checkpoint.Checkpoint;
 import org.bsc.langgraph4j.internal.node.ParallelNode;
 import org.bsc.langgraph4j.state.AgentState;
 import org.bsc.langgraph4j.state.Channel;
 import org.bsc.langgraph4j.state.Channels;
+import org.bsc.langgraph4j.streaming.StreamingOutput;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +29,8 @@ import java.util.stream.IntStream;
 
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.bsc.langgraph4j.StateGraph.END;
+import static org.bsc.langgraph4j.StateGraph.START;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ParallelNodeTest {
@@ -83,7 +92,7 @@ public class ParallelNodeTest {
 
         var parallelNode = new ParallelNode<>("parallelNodeTest", actions, State.SCHEMA);
 
-        var parallelNodeAction = parallelNode.actionFactory().apply(CompileConfig.builder().build());
+        var parallelNodeAction = compileParallelNodeAction(parallelNode);
 
         Map<String, Object> initialData = Map.of("item1", "test1", "task-2", "test2");
 
@@ -147,7 +156,7 @@ public class ParallelNodeTest {
 
         var parallelNode = new ParallelNode<>("parallelNodeTest", actions, State.SCHEMA);
 
-        var parallelNodeAction = parallelNode.actionFactory().apply(CompileConfig.builder().build());
+        var parallelNodeAction = compileParallelNodeAction(parallelNode);
 
         Map<String, Object> initialData = Map.of("item1", "test1");
 
@@ -201,7 +210,7 @@ public class ParallelNodeTest {
 
         var parallelNode = new ParallelNode<>("parallelNodeTest", actions, State.SCHEMA);
 
-        var parallelNodeAction = parallelNode.actionFactory().apply(CompileConfig.builder().build());
+        var parallelNodeAction = compileParallelNodeAction(parallelNode);
 
         Map<String, Object> initialData = Map.of("item1", "test1", "task-2", "test2");
 
@@ -213,6 +222,261 @@ public class ParallelNodeTest {
 
         assertInstanceOf( RuntimeException.class, exception.getCause() );
 
+    }
+
+    // streaming action carrying the final business state only in the generator result value (Data.done(...)), like StreamingChatGenerator
+    private static AsyncNodeActionWithConfig<State> compileParallelNodeAction(ParallelNode<State> parallelNode) {
+        return assertDoesNotThrow(() -> parallelNode.actionFactory().apply(CompileConfig.builder().build()));
+    }
+
+    private static AsyncNodeActionWithConfig<State> createSyncStreamingAction(String key, String value) {
+
+        return ( state, config ) -> {
+            final Iterator<String> iterator = List.of("chunk-1", "chunk-2").iterator();
+            final var generator = new AsyncGenerator.Base<StreamingOutput<State>>() {
+                @Override
+                public Data<StreamingOutput<State>> next() {
+                    if (iterator.hasNext()) {
+                        return AsyncGenerator.Data.of(new StreamingOutput<>(iterator.next(), "streaming", state, null));
+                    }
+                    return (value == null) ? AsyncGenerator.Data.done() : AsyncGenerator.Data.done(Map.of(key, value));
+                }
+            };
+            return completedFuture(Map.of("content", generator));
+        };
+    }
+
+    private static AsyncNodeActionWithConfig<State> createAsyncStreamingAction(String key, String value) {
+
+        return ( state, config ) -> {
+            BlockingQueue<AsyncGenerator.Data<StreamingOutput<State>>> queue = new LinkedBlockingQueue<>();
+            CompletableFuture.runAsync(() -> {
+                for (String chunk : List.of("chunk-1", "chunk-2")) {
+                    queue.add(AsyncGenerator.Data.of(new StreamingOutput<>(chunk, "streaming", state, null)));
+                }
+                queue.add(AsyncGenerator.Data.done(Map.of(key, value)));
+            });
+            return completedFuture(Map.of("content", new AsyncGeneratorQueue.Generator<>(queue)));
+        };
+    }
+
+    private static AsyncNodeActionWithConfig<State> createStreamingActionWithResult(Object resultValue) {
+        return (state, config) -> completedFuture(Map.of("content", new AsyncGenerator.Base<StreamingOutput<State>>() {
+            private boolean done;
+
+            @Override
+            public Data<StreamingOutput<State>> next() {
+                if (done) {
+                    throw new IllegalStateException("generator already completed");
+                }
+                done = true;
+                return AsyncGenerator.Data.done(resultValue);
+            }
+        }));
+    }
+
+    @Test
+    public void parallelNodeWithSyncStreamingActionTest() {
+
+        var actions = List.of(
+                createSyncStreamingAction("task", "LEFT"),
+                createSyncStreamingAction("task", "RIGHT"));
+
+        var parallelNode = new ParallelNode<>("parallelStreamingTest", actions, State.SCHEMA);
+
+        var parallelNodeAction = compileParallelNodeAction(parallelNode);
+
+        var agentState = new State(new LinkedHashMap<>(Map.of("item1", "test1")));
+
+        var result = parallelNodeAction.apply(agentState, RunnableConfig.builder().build()).join();
+
+        var newState = new State(result);
+
+        assertEquals( 2, newState.completedTasks().size() );
+        assertTrue( newState.completedTasks().contains("LEFT") );
+        assertTrue( newState.completedTasks().contains("RIGHT") );
+        assertEquals( "test1", newState.value("item1").orElseThrow() );
+    }
+
+    @Test
+    public void parallelNodeWithAsyncStreamingActionTest() {
+
+        var actions = List.of(
+                createAsyncStreamingAction("task", "LEFT"),
+                createAsyncStreamingAction("task", "RIGHT"));
+
+        var parallelNode = new ParallelNode<>("parallelStreamingTest", actions, State.SCHEMA);
+
+        var parallelNodeAction = compileParallelNodeAction(parallelNode);
+
+        var agentState = new State(new LinkedHashMap<>(Map.of("item1", "test1")));
+
+        var result = parallelNodeAction.apply(agentState, RunnableConfig.builder().build()).join();
+
+        var newState = new State(result);
+
+        assertEquals( 2, newState.completedTasks().size() );
+        assertTrue( newState.completedTasks().contains("LEFT") );
+        assertTrue( newState.completedTasks().contains("RIGHT") );
+        assertEquals( "test1", newState.value("item1").orElseThrow() );
+    }
+
+    @Test
+    public void parallelNodeWithStreamingActionWithoutResultValueTest() {
+
+        var actions = List.of(
+                createSyncStreamingAction("task", "LEFT"),
+                createSyncStreamingAction("task", null));
+
+        var parallelNode = new ParallelNode<>("parallelStreamingTest", actions, State.SCHEMA);
+
+        var parallelNodeAction = compileParallelNodeAction(parallelNode);
+
+        var agentState = new State(new LinkedHashMap<>(Map.of("item1", "test1")));
+
+        var result = parallelNodeAction.apply(agentState, RunnableConfig.builder().build()).join();
+
+        var newState = new State(result);
+
+        assertEquals( 1, newState.completedTasks().size() );
+        assertTrue( newState.completedTasks().contains("LEFT") );
+        assertEquals( "test1", newState.value("item1").orElseThrow() );
+    }
+
+    @Test
+    public void parallelBranchWithStreamingNodesEndToEndTest() {
+
+        var workflow = assertDoesNotThrow(() -> new StateGraph<State>(State::new)
+                .addNode("left", createSyncStreamingAction("left", "L"))
+                .addNode("right", createSyncStreamingAction("right", "R"))
+                .addEdge(START, "left")
+                .addEdge(START, "right")
+                .addEdge("left", END)
+                .addEdge("right", END)
+                .compile());
+
+        var result = assertDoesNotThrow(() -> workflow.invoke(Map.of(), RunnableConfig.builder().build()));
+
+        assertTrue( result.isPresent() );
+        assertEquals( "L", result.get().data().get("left") );
+        assertEquals( "R", result.get().data().get("right") );
+    }
+
+    @Test
+    public void parallelNodeWithEmptyStreamingResultTest() {
+        var parallelNode = new ParallelNode<State>("parallelStreamingTest",
+                List.of(createStreamingActionWithResult(Map.of())), State.SCHEMA);
+
+        var result = compileParallelNodeAction(parallelNode)
+                .apply(new State(new LinkedHashMap<>(Map.of("item1", "test1"))), RunnableConfig.builder().build())
+                .join();
+
+        assertEquals("test1", result.get("item1"));
+        assertFalse(result.containsKey("content"));
+    }
+
+    @Test
+    public void parallelNodeWithCancelledStreamingResultTest() {
+        var parallelNode = new ParallelNode<State>("parallelStreamingTest",
+                List.of(createStreamingActionWithResult(AsyncGenerator.IsCancellable.CANCELLED)), State.SCHEMA);
+
+        var result = compileParallelNodeAction(parallelNode)
+                .apply(new State(new LinkedHashMap<>(Map.of("item1", "test1"))), RunnableConfig.builder().build())
+                .join();
+
+        assertEquals("test1", result.get("item1"));
+        assertFalse(result.containsKey("content"));
+    }
+
+    @Test
+    public void parallelNodeWithCheckpointStreamingResultTest() {
+        var checkpoint = Checkpoint.builder()
+                .state(Map.of("task", "FROM_CHECKPOINT"))
+                .nodeId("streaming")
+                .nextNodeId(END)
+                .build();
+        var checkpointTag = new BaseCheckpointSaver.Tag("thread", List.of(checkpoint));
+        var parallelNode = new ParallelNode<State>("parallelStreamingTest",
+                List.of(createStreamingActionWithResult(checkpointTag)), State.SCHEMA);
+
+        var result = compileParallelNodeAction(parallelNode)
+                .apply(new State(new LinkedHashMap<>(Map.of("item1", "test1"))), RunnableConfig.builder().build())
+                .join();
+
+        var newState = new State(result);
+        assertEquals(List.of("FROM_CHECKPOINT"), newState.completedTasks());
+        assertEquals("test1", newState.value("item1").orElseThrow());
+    }
+
+    @Test
+    public void parallelNodeRejectsInvalidStreamingResultValueTest() {
+        var parallelNode = new ParallelNode<State>("parallelStreamingTest",
+                List.of(createStreamingActionWithResult("not-state-data")), State.SCHEMA);
+
+        var exception = assertThrows(CompletionException.class, () ->
+                compileParallelNodeAction(parallelNode)
+                        .apply(new State(Map.of()), RunnableConfig.builder().build())
+                        .join());
+
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+        assertEquals("Invalid result type: class java.lang.String", exception.getCause().getMessage());
+    }
+
+    @Test
+    public void parallelNodeRejectsNodeOutputStreamingResultTest() {
+        var nodeOutput = NodeOutput.of("streaming", new State(Map.of()));
+        var parallelNode = new ParallelNode<State>("parallelStreamingTest",
+                List.of(createStreamingActionWithResult(nodeOutput)), State.SCHEMA);
+
+        var exception = assertThrows(CompletionException.class, () ->
+                compileParallelNodeAction(parallelNode)
+                        .apply(new State(Map.of()), RunnableConfig.builder().build())
+                        .join());
+
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+        assertEquals("Unsupported parallel branch streaming result type: NODE_OUTPUT",
+                exception.getCause().getMessage());
+    }
+
+    @Test
+    public void parallelNodeRejectsInterruptionStreamingResultTest() {
+        var interruption = InterruptionMetadata.builder("streaming", new State(Map.of())).build();
+        var parallelNode = new ParallelNode<State>("parallelStreamingTest",
+                List.of(createStreamingActionWithResult(interruption)), State.SCHEMA);
+
+        var exception = assertThrows(CompletionException.class, () ->
+                compileParallelNodeAction(parallelNode)
+                        .apply(new State(Map.of()), RunnableConfig.builder().build())
+                        .join());
+
+        assertInstanceOf(UnsupportedOperationException.class, exception.getCause());
+        assertEquals("Interruption metadata cannot be returned from a parallel branch streaming generator",
+                exception.getCause().getMessage());
+    }
+
+    @Test
+    public void parallelNodeWithAsyncStreamingActionAndExecutorTest() {
+        var actionThread = new CompletableFuture<String>();
+        AsyncNodeActionWithConfig<State> action = (state, config) -> {
+            actionThread.complete(Thread.currentThread().getName());
+            return createAsyncStreamingAction("task", "EXECUTOR").apply(state, config);
+        };
+        var parallelNode = new ParallelNode<State>("parallelStreamingTest", List.of(action), State.SCHEMA);
+        var executor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "parallel-streaming-test"));
+
+        try {
+            var config = RunnableConfig.builder()
+                    .addParallelNodeExecutor("parallelStreamingTest", executor)
+                    .build();
+            var result = compileParallelNodeAction(parallelNode)
+                    .apply(new State(Map.of()), config)
+                    .join();
+
+            assertEquals("parallel-streaming-test", actionThread.join());
+            assertEquals(List.of("EXECUTOR"), new State(result).completedTasks());
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #451

## Summary

Fixes loss of the final `Data.done(...)` state returned by streaming actions
when they run as branches of a `ParallelNode`.

Parallel branches now wrap their streaming generator with `AsyncGenerator.WithEmbed`,
retrieve the final result, and merge supported state values with the configured
channel reducers.

## Behavior

- Merge `Map` final results through `AgentState.updateState(...)`
- Support checkpoint-tag final results consistently with the serial streaming path
- Preserve empty and cancelled final results without state changes
- Reject unsupported final results with explicit errors:
  - `InterruptionMetadata`: not independently propagatable from a parallel branch
  - `NODE_OUTPUT`: not a valid branch state result

## Tests

Added coverage for:

- synchronous and asynchronous streaming branches
- no final value, empty map, and cancellation
- checkpoint-tag final values
- invalid raw values, `NODE_OUTPUT`, and `InterruptionMetadata`
- configured parallel executor
- end-to-end graph execution

Validated locally:

```text
mvn -pl langgraph4j-core clean test -Dtest=ParallelNodeTest
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langgraph4j-core test
tests=127, failures=0, errors=0, skipped=0