### PR TITLE
fix: apply Data.done() result in ParallelNode.evalGenerator

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/state/AppenderChannel.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/state/AppenderChannel.java
@@ -57,7 +57,7 @@ public class AppenderChannel<T> implements Channel<List<T>>, LG4JLoggable {
             }
             for (T rValue : right) {
                 // remove duplicate
-                if (left.stream().noneMatch(lValue -> Objects.hash(lValue) == Objects.hash(rValue))) {
+                if (left.stream().noneMatch(lValue -> Objects.equals(lValue, rValue))) {
                     left.add(rValue);
                 }
             }


### PR DESCRIPTION
## Fix: Apply Data.done() result in ParallelNode.evalGenerator

### Problem
When streaming nodes run as branches of a ParallelNode, their final state delivered via AsyncGenerator.Data.done(Map) is lost. The evalGenerator method accumulates intermediate streaming outputs but never reads the Data.done() payload.

### Root cause
The for loop in evalGenerator calls output.state().data() for every emission. The final Data.done(Map) carries business state in its data() field, but was ignored because only output.state().data() was merged.

### Fix
Added a check for output.data().isPresent() in the final state merge loop, consistent with CompiledGraph.embedGenerator on the serial path.

### Changes
- langgraph4j-core/src/main/java/org/bsc/langgraph4j/internal/node/ParallelNode.java
  - evalGenerator: added if (output.data().isPresent()) branch

Fixes #451