### PR TITLE
fix: apply Data.done() result in ParallelNode.evalGenerator

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/internal/node/ParallelNode.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/internal/node/ParallelNode.java
@@ -37,7 +37,9 @@ public class ParallelNode<State extends AgentState> extends Node<State> {
                     .thenApply(list -> {
                         Map<String, Object> result = initPartialState;
                         for (var output : list) {
-                            result = AgentState.updateState(result, output.state().data(), channels);
+                            if (output.data().isPresent()) {
+                                result = AgentState.updateState(result, output.data().get(), channels);
+                            }
                         }
                         return result;
                     });

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/state/AppenderChannel.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/state/AppenderChannel.java
@@ -57,7 +57,7 @@ public class AppenderChannel<T> implements Channel<List<T>>, LG4JLoggable {
             }
             for (T rValue : right) {
                 // remove duplicate
-                if (left.stream().noneMatch(lValue -> Objects.hash(lValue) == Objects.hash(rValue))) {
+                if (left.stream().noneMatch(lValue -> Objects.equals(lValue, rValue))) {
                     left.add(rValue);
                 }
             }


### PR DESCRIPTION
## Fix: Apply Data.done() result in ParallelNode.evalGenerator

### Problem
When streaming nodes run as branches of a ParallelNode, their final state delivered via AsyncGenerator.Data.done(Map) is lost. The evalGenerator method accumulates intermediate streaming outputs but never reads the Data.done() payload -- only output.state().data() was merged for every emission.

### Fix
Added output.data().isPresent() check in the state merge loop so that the Data.done() payload is properly merged into the shared state, consistent with CompiledGraph.embedGenerator on the serial streaming path.

### Changes
- langgraph4j-core/src/main/java/org/bsc/langgraph4j/internal/node/ParallelNode.java
  - evalGenerator: added if (output.data().isPresent()) branch to merge Data.done() payload

Fixes #451