### PR TITLE
refactor: rename InterruptableAction to InterruptibleAction (8 files)

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/action/AsyncNodeAction.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/action/AsyncNodeAction.java
@@ -44,9 +44,9 @@ public interface AsyncNodeAction<S extends AgentState> extends Function<S, Compl
             }
         };
 
-        if( syncAction instanceof InterruptableAction<?> ) {
+        if( syncAction instanceof InterruptibleAction<?> ) {
             final var proxyInstance = Proxy.newProxyInstance( syncAction.getClass().getClassLoader(),
-                    new Class[] { AsyncNodeAction.class, InterruptableAction.class},
+                    new Class[] { AsyncNodeAction.class, InterruptibleAction.class},
                     (proxy, method, methodArgs) -> {
                         if( method.getName().equals("interrupt") ) {
                             return method.invoke(syncAction, methodArgs);

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/action/AsyncNodeActionWithConfig.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/action/AsyncNodeActionWithConfig.java
@@ -53,9 +53,9 @@ public interface AsyncNodeActionWithConfig<S extends AgentState> extends BiFunct
             }
         };
 
-        if( syncAction instanceof InterruptableAction<?> ) {
+        if( syncAction instanceof InterruptibleAction<?> ) {
             final var proxyInstance = Proxy.newProxyInstance( syncAction.getClass().getClassLoader(),
-                    new Class[] { AsyncNodeActionWithConfig.class, InterruptableAction.class},
+                    new Class[] { AsyncNodeActionWithConfig.class, InterruptibleAction.class},
                     (proxy, method, methodArgs) -> {
                         if( method.getName().equals("interrupt") ) {
                             return method.invoke(syncAction, methodArgs);
@@ -81,9 +81,9 @@ public interface AsyncNodeActionWithConfig<S extends AgentState> extends BiFunct
         final AsyncNodeActionWithConfig<S> actionWithConfig = (t, config ) ->
                 action.apply(t);
 
-        if( action instanceof InterruptableAction<?> ) {
+        if( action instanceof InterruptibleAction<?> ) {
             final var proxyInstance = Proxy.newProxyInstance( action.getClass().getClassLoader(),
-                    new Class[] { AsyncNodeActionWithConfig.class, InterruptableAction.class},
+                    new Class[] { AsyncNodeActionWithConfig.class, InterruptibleAction.class},
                     (proxy, method, methodArgs) -> {
                         if( method.getName().equals("interrupt") ) {
                             return method.invoke(action, methodArgs);

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/action/InterruptableAction.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/action/InterruptableAction.java
@@ -1,44 +1,13 @@
 package org.bsc.langgraph4j.action;
 
-import org.bsc.langgraph4j.RunnableConfig;
 import org.bsc.langgraph4j.state.AgentState;
-
-import java.util.Optional;
 
 /**
  * Defines a contract for actions that can interrupt the execution of a graph.
- * This is a functional interface whose functional method is {@link #interrupt(String, AgentState)}.
  *
  * @param <State> The type of the agent state, which must extend {@link AgentState}.
+ * @deprecated use {@link InterruptibleAction} instead
  */
-public interface InterruptableAction<State extends AgentState> {
-
-    /**
-     * Determines whether the graph execution should be interrupted at the current node.
-     *
-     * @param nodeId The identifier of the current node being processed.
-     * @param state  The current state of the agent.
-     * @return An {@link Optional} containing {@link InterruptionMetadata} if the execution
-     *         should be interrupted. Returns an empty {@link Optional} to continue execution.
-*    * @deprecated use {@link #interrupt(String,State,RunnableConfig)} instead
-     */
-    @Deprecated(forRemoval = true)
-    default Optional<InterruptionMetadata<State>> interrupt(String nodeId, State state ) {
-        return Optional.empty();
-    }
-
-    /**
-     * Determines whether the graph execution should be interrupted at the current node.
-     * override this method if you need information by current RunnableConfig
-     *
-     * @param nodeId The identifier of the current node being processed.
-     * @param state  The current state of the agent.
-     * @param config The runnable configuration.
-     * @return An {@link Optional} containing {@link InterruptionMetadata} if the execution
-     *         should be interrupted. Returns an empty {@link Optional} to continue execution.
-     */
-    default Optional<InterruptionMetadata<State>> interrupt(String nodeId, State state, RunnableConfig config ) {
-        return interrupt(nodeId, state);
-    }
-
+@Deprecated(forRemoval = true)
+public interface InterruptableAction<State extends AgentState> extends InterruptibleAction<State> {
 }

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/action/InterruptibleAction.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/action/InterruptibleAction.java
@@ -1,0 +1,44 @@
+package org.bsc.langgraph4j.action;
+
+import org.bsc.langgraph4j.RunnableConfig;
+import org.bsc.langgraph4j.state.AgentState;
+
+import java.util.Optional;
+
+/**
+ * Defines a contract for actions that can interrupt the execution of a graph.
+ * This is a functional interface whose functional method is {@link #interrupt(String, AgentState)}.
+ *
+ * @param <State> The type of the agent state, which must extend {@link AgentState}.
+ */
+public interface InterruptibleAction<State extends AgentState> {
+
+    /**
+     * Determines whether the graph execution should be interrupted at the current node.
+     *
+     * @param nodeId The identifier of the current node being processed.
+     * @param state  The current state of the agent.
+     * @return An {@link Optional} containing {@link InterruptionMetadata} if the execution
+     *         should be interrupted. Returns an empty {@link Optional} to continue execution.
+     * @deprecated use {@link #interrupt(String,State,RunnableConfig)} instead
+     */
+    @Deprecated(forRemoval = true)
+    default Optional<InterruptionMetadata<State>> interrupt(String nodeId, State state ) {
+        return Optional.empty();
+    }
+
+    /**
+     * Determines whether the graph execution should be interrupted at the current node.
+     * override this method if you need information by current RunnableConfig
+     *
+     * @param nodeId The identifier of the current node being processed.
+     * @param state  The current state of the agent.
+     * @param config The runnable configuration.
+     * @return An {@link Optional} containing {@link InterruptionMetadata} if the execution
+     *         should be interrupted. Returns an empty {@link Optional} to continue execution.
+     */
+    default Optional<InterruptionMetadata<State>> interrupt(String nodeId, State state, RunnableConfig config ) {
+        return interrupt(nodeId, state);
+    }
+
+}

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/agent/AgentEx.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/agent/AgentEx.java
@@ -60,7 +60,7 @@ public interface AgentEx {
         REJECTED
     }
 
-    final class ApprovalNodeAction<M, State extends MessagesState<M>> implements AsyncNodeActionWithConfig<State>, InterruptableAction<State> {
+    final class ApprovalNodeAction<M, State extends MessagesState<M>> implements AsyncNodeActionWithConfig<State>, InterruptibleAction<State> {
 
         private final BiFunction<String, State, InterruptionMetadata<State>> interruptionMetadataProvider;
 

--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/internal/hook/NodeHooks.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/internal/hook/NodeHooks.java
@@ -6,7 +6,7 @@ import org.bsc.langgraph4j.GraphStateException;
 import org.bsc.langgraph4j.RunnableConfig;
 import org.bsc.langgraph4j.StateGraph;
 import org.bsc.langgraph4j.action.AsyncNodeActionWithConfig;
-import org.bsc.langgraph4j.action.InterruptableAction;
+import org.bsc.langgraph4j.action.InterruptibleAction;
 import org.bsc.langgraph4j.action.InterruptionMetadata;
 import org.bsc.langgraph4j.hook.NodeHook;
 import org.bsc.langgraph4j.state.AgentState;
@@ -163,9 +163,9 @@ public class NodeHooks<State extends AgentState> {
                                                                  RunnableConfig config,
                                                                  AsyncNodeActionWithConfig<State> action)
     {
-        if( action instanceof InterruptableAction<?>) {
+        if( action instanceof InterruptibleAction<?>) {
             @SuppressWarnings("unchecked")
-            final var interruption = (InterruptableAction<State>) action;
+            final var interruption = (InterruptibleAction<State>) action;
             final var interruptMetadata = interruption.interrupt( config.nodeId(), newState, config );
             if( interruptMetadata.isPresent() ) {
                 return new Result<>( interruptMetadata.get() );

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/InterruptionTest.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/InterruptionTest.java
@@ -3,7 +3,7 @@ package org.bsc.langgraph4j;
 import org.bsc.async.AsyncGenerator;
 import org.bsc.async.AsyncGeneratorQueue;
 import org.bsc.langgraph4j.action.AsyncNodeActionWithConfig;
-import org.bsc.langgraph4j.action.InterruptableAction;
+import org.bsc.langgraph4j.action.InterruptibleAction;
 import org.bsc.langgraph4j.action.InterruptionMetadata;
 import org.bsc.langgraph4j.checkpoint.MemorySaver;
 import org.bsc.langgraph4j.prebuilt.MessagesState;
@@ -46,7 +46,7 @@ public class InterruptionTest {
 
     static class CustomAction implements AsyncNodeActionWithConfig<MessagesState<String>> {
 
-        static class Interruptable extends CustomAction implements InterruptableAction<MessagesState<String>> {
+        static class Interruptable extends CustomAction implements InterruptibleAction<MessagesState<String>> {
             private final boolean interrupt;
 
             private Interruptable(Builder builder) {

--- a/langgraph4j-core/src/test/java/org/bsc/langgraph4j/Issue304Test.java
+++ b/langgraph4j-core/src/test/java/org/bsc/langgraph4j/Issue304Test.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class Issue304Test {
 
-    static class NodeActionTest implements NodeAction<AgentState>, InterruptableAction<AgentState> {
+    static class NodeActionTest implements NodeAction<AgentState>, InterruptibleAction<AgentState> {
 
         @Override
         public Map<String, Object> apply(AgentState state) throws Exception {
@@ -30,7 +30,7 @@ public class Issue304Test {
         }
     }
 
-    static class NodeActionWithConfigTest implements NodeActionWithConfig<AgentState>, InterruptableAction<AgentState> {
+    static class NodeActionWithConfigTest implements NodeActionWithConfig<AgentState>, InterruptibleAction<AgentState> {
 
         @Override
         public Map<String, Object> apply(AgentState state, RunnableConfig config)  {
@@ -43,7 +43,7 @@ public class Issue304Test {
         }
     }
 
-    static class AsyncNodeActionTest implements AsyncNodeAction<AgentState>, InterruptableAction<AgentState> {
+    static class AsyncNodeActionTest implements AsyncNodeAction<AgentState>, InterruptibleAction<AgentState> {
 
         @Override
         public CompletableFuture<Map<String, Object>> apply(AgentState state)  {
@@ -61,12 +61,12 @@ public class Issue304Test {
         final var action = new NodeActionTest();
 
         var proxyInstance = Proxy.newProxyInstance( getClass().getClassLoader(),
-                new Class[] { NodeAction.class, InterruptableAction.class},
+                new Class[] { NodeAction.class, InterruptibleAction.class},
                 (proxy, method, methodArgs) -> {
                     return method.invoke(action, methodArgs);
                 });
 
-        assertInstanceOf(InterruptableAction.class, proxyInstance);
+        assertInstanceOf(InterruptibleAction.class, proxyInstance);
         assertInstanceOf(NodeAction.class, proxyInstance);
 
         @SuppressWarnings("unchecked")
@@ -79,7 +79,7 @@ public class Issue304Test {
         assertIterableEquals( Map.of("k1", "v1").entrySet(), result.entrySet() );
 
         @SuppressWarnings("unchecked")
-        final var interruptableAction = (InterruptableAction<AgentState>)proxyInstance;
+        final var interruptableAction = (InterruptibleAction<AgentState>)proxyInstance;
 
         var resultMetadata = interruptableAction.interrupt( "node1", state, RunnableConfig.builder().build() );
         assertInstanceOf(Optional.class, resultMetadata);
@@ -99,10 +99,10 @@ public class Issue304Test {
         assertInstanceOf(Map.class, result);
         assertIterableEquals( Map.of("k1", "v1").entrySet(), result.entrySet() );
 
-        assertInstanceOf(InterruptableAction.class, nodeAction);
+        assertInstanceOf(InterruptibleAction.class, nodeAction);
 
         @SuppressWarnings("unchecked")
-        final var interruptableAction = (InterruptableAction<AgentState>)nodeAction;
+        final var interruptableAction = (InterruptibleAction<AgentState>)nodeAction;
 
         var resultMetadata = interruptableAction.interrupt( "node1", state, RunnableConfig.builder().build() );
         assertInstanceOf(Optional.class, resultMetadata);
@@ -123,10 +123,10 @@ public class Issue304Test {
         assertInstanceOf(Map.class, result);
         assertIterableEquals( Map.of("k1", "v1").entrySet(), result.entrySet() );
 
-        assertInstanceOf(InterruptableAction.class, nodeAction);
+        assertInstanceOf(InterruptibleAction.class, nodeAction);
 
         @SuppressWarnings("unchecked")
-        final var interruptableAction = (InterruptableAction<AgentState>)nodeAction;
+        final var interruptableAction = (InterruptibleAction<AgentState>)nodeAction;
 
         var resultMetadata = interruptableAction.interrupt( "node1", state, RunnableConfig.builder().build() );
         assertInstanceOf(Optional.class, resultMetadata);
@@ -147,10 +147,10 @@ public class Issue304Test {
         assertInstanceOf(Map.class, result);
         assertIterableEquals( Map.of("k1", "v1").entrySet(), result.entrySet() );
 
-        assertInstanceOf(InterruptableAction.class, asyncNodeAction);
+        assertInstanceOf(InterruptibleAction.class, asyncNodeAction);
 
         @SuppressWarnings("unchecked")
-        final var interruptableAction = (InterruptableAction<AgentState>)asyncNodeAction;
+        final var interruptableAction = (InterruptibleAction<AgentState>)asyncNodeAction;
 
         var resultMetadata = interruptableAction.interrupt( "node1", state, RunnableConfig.builder().build() );
         assertInstanceOf(Optional.class, resultMetadata);

--- a/src/site/mkdocs/core/core-library.md
+++ b/src/site/mkdocs/core/core-library.md
@@ -671,12 +671,12 @@ var compileConfig = CompileConfig.builder()
 
 ### Dynamic definition
 
-The `org.bsc.langgraph4j.action.InterruptableAction<State>` interface is the core component that enables this functionality. Any node action that implements this interface can conditionally interrupt the graph's execution.
+The `org.bsc.langgraph4j.action.InterruptibleAction<State>` interface is the core component that enables this functionality. Any node action that implements this interface can conditionally interrupt the graph's execution.
 
 The heart of the interface is the interrupt method:
 
 ```java
-public interface InterruptableAction<State extends AgentState> {
+public interface InterruptibleAction<State extends AgentState> {
    /**
     * Determines whether the graph execution should be interrupted at the current node.
     *
@@ -689,9 +689,11 @@ public interface InterruptableAction<State extends AgentState> {
 }
 ```
 
+The legacy name `InterruptableAction` is still available as a deprecated alias of `InterruptibleAction` for backward compatibility.
+
 **Here’s how it works**:
 
- * When the graph is about to execute a node, it first checks if the node's action implements InterruptableAction.
+ * When the graph is about to execute a node, it first checks if the node's action implements InterruptibleAction.
  * If it does, the interrupt(String nodeId, State state) method is called.
  * If the method returns a non-empty Optional<InterruptionMetadata>, the graph's execution is paused. The InterruptionMetadata object contains information about the
   interruption, which can be sent to an external system or user for review.


### PR DESCRIPTION
## refactor: rename InterruptableAction to InterruptibleAction

Problem: `Interruptable` is not standard English. The correct adjective is `Interruptible` (from the verb *interrupt*).

Changes (based on `develop`):
- Added new interface `InterruptibleAction` with the current methods.
- Kept the old `InterruptableAction` name as a **deprecated alias** extending `InterruptibleAction`, preserving backward compatibility for existing implementations.
- Updated references in `AsyncNodeAction`, `AsyncNodeActionWithConfig`, `AgentEx`, `NodeHooks`, tests and docs to use the new name.

Existing code implementing the legacy `InterruptableAction` keeps working unchanged (it is now a subtype of the new interface).