### PR TITLE
docs: document AgentState reset and removal markers

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/state/AgentState.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/state/AgentState.java
@@ -16,10 +16,34 @@ import static org.bsc.langgraph4j.utils.CollectionsUtils.entryOf;
  * Represents the state of an agent with a map of data.
  */
 public class AgentState {
+    /**
+     * Marker value that resets a state entry through its configured {@link Channel}.
+     * <p>
+     * When used as a value in a partial state update, the current value is replaced
+     * with the channel's default value. If the channel has no default value, or no
+     * channel is configured for the key, the key is removed from the resulting state.
+     * The marker is handled before any configured {@link Reducer} is invoked.
+     * <p>
+     * This marker is recognized by identity; use this constant directly.
+     *
+     * @see Channel#update(String, Object, Object)
+     */
     public static final Object MARK_FOR_RESET = new Object() {
         @Override
         public String toString() { return "MARK_FOR_RESET"; }
     };
+
+    /**
+     * Marker value that removes a state entry.
+     * <p>
+     * When used as a value in a partial state update, the corresponding key is
+     * excluded from the resulting state. The marker is handled before any configured
+     * {@link Reducer} is invoked.
+     * <p>
+     * This marker is recognized by identity; use this constant directly.
+     *
+     * @see Channel#update(String, Object, Object)
+     */
     public static final Object MARK_FOR_REMOVAL = new Object() {
         @Override
         public String toString() { return "MARK_FOR_REMOVAL"; }


### PR DESCRIPTION
## Summary

- document how `MARK_FOR_RESET` restores a channel's default value or removes the key when no default is available
- document how `MARK_FOR_REMOVAL` excludes the corresponding key from the resulting state
- clarify that both markers are identity-based and handled before configured reducers

## Testing

- targeted state marker tests pass
- `langgraph4j-core` Javadoc generation succeeds
- `git diff --check` passes
- full core suite: 115 of 116 tests pass; the remaining test has an existing Windows-specific line-ending mismatch in `StateGraphRepresentationTest.issue216Test`, which is reproducible on the unchanged `main` branch

Closes #458