### PR TITLE
docs: document thread_id uniqueness for checkpoint persistence

### DIFF
--- a/how-tos/persistence.ipynb
+++ b/how-tos/persistence.ipynb
@@ -741,6 +741,36 @@
     "// Shut down the embedded member when done (the caller owns the HazelcastInstance lifecycle).\n",
     "hz.shutdown();"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Thread ID Uniqueness & Checkpoint Persistence\n",
+    "\n",
+    "When a persistent [`CheckpointSaver`] is in use, the **`thread_id`** acts as the\n",
+    "primary key of the checkpoint storage (see [#321] for a concrete failure report).\n",
+    "Keep the following in mind:\n",
+    "\n",
+    "1. A `thread_id` identifies one conversation timeline: reuse the same id to\n",
+    "   *continue* that conversation, and generate a fresh one to start a new\n",
+    "   conversation.\n",
+    "1. Generate ids programmatically, e.g. `UUID.randomUUID()`, optionally prefixed\n",
+    "   with a tenant/session qualifier (`<tenant>-<session>-<uuid>`) when several\n",
+    "   clients share the same storage.\n",
+    "1. Reusing a `thread_id` that already has checkpoints does **not** start a clean\n",
+    "   conversation: persistent savers will reject the conflicting insert (typically\n",
+    "   a primary-key violation).\n",
+    "\n",
+    "Note that UI tooling (such as LangGraph Studio) may reuse default thread names\n",
+    "like `default` or `thread_1` across restarts: when running against a persistent\n",
+    "saver, always provide a freshly generated `thread_id` in your\n",
+    "[`RunnableConfig`].\n",
+    "\n",
+    "[#321]: https://github.com/langgraph4j/langgraph4j/issues/321\n",
+    "[`CheckpointSaver`]: https://langgraph4j.github.io/langgraph4j/apidocs/org/bsc/langgraph4j/checkpoint/BaseCheckpointSaver.html\n",
+    "[`RunnableConfig`]: https://langgraph4j.github.io/langgraph4j/apidocs/org/bsc/langgraph4j/RunnableConfig.html"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
As agreed with @bsorrentino in #321, this adds a short section to the persistence how-to documenting `thread_id` semantics when a persistent `CheckpointSaver` is configured:

- `thread_id` must be unique per conversation timeline,
- recommended generation strategy (UUID + tenant/session prefix),
- what happens on reuse (primary-key violation in persistent savers, as reported in #321).

Refs #321